### PR TITLE
Migrate `chainbridge` pallet to Substrate FRAME v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,15 +14,15 @@ jobs:
           - x86_64-unknown-linux-gnu
     steps:
       - name: Checkout source code
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
       - name: Install latest nightly Rust toolchain
-      - uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           target: ${{ matrix.target }}
           override: true
       - name: Build chainbridge Rust crate
-      - uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,15 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
     steps:
+      - name: Checkout source code
       - uses: actions/checkout@v2
+      - name: Install latest nightly Rust toolchain
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-11-30
+          toolchain: nightly
           target: ${{ matrix.target }}
           override: true
-      - name: Build
+      - name: Build chainbridge Rust crate
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -35,10 +37,12 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
     steps:
+      - name: Checkout source code
       - uses: actions/checkout@v2
+      - name: Install latest nightly Rust toolchain
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-06
+          toolchain: nightly
           target: ${{ matrix.target }}
           override: true
       - name: Build
@@ -58,7 +62,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-06
+          toolchain: nightly
           target: ${{ matrix.target }}
           components: rustfmt
           override: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,3 @@
-
 name: Tests
 
 on:
@@ -23,7 +22,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - name: Build chainbridge Rust crate
-        uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build
@@ -38,14 +37,14 @@ jobs:
           - x86_64-unknown-linux-gnu
     steps:
       - name: Checkout source code
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
       - name: Install latest nightly Rust toolchain
-      - uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           target: ${{ matrix.target }}
           override: true
-      - name: Build
+      - name: Build Rust create
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -66,7 +65,7 @@ jobs:
           target: ${{ matrix.target }}
           components: rustfmt
           override: true
-      - name: Build
+      - name: Format Rust source code
         uses: actions-rs/cargo@v1
         with:
           use-cross: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,16 +252,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chainbridge"
 version = "0.0.2"
 dependencies = [
- "frame-support 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "frame-system 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "pallet-balances 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
  "parity-scale-codec",
  "serde",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-io 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "substrate-wasm-builder-runner 3.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "substrate-wasm-builder-runner",
 ]
 
 [[package]]
@@ -460,42 +460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "example-erc721"
-version = "0.0.1"
-dependencies = [
- "chainbridge",
- "frame-support 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-balances 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec",
- "serde",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-wasm-builder-runner 2.0.0",
-]
-
-[[package]]
-name = "example-pallet"
-version = "0.0.1"
-dependencies = [
- "chainbridge",
- "example-erc721",
- "frame-support 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-balances 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec",
- "serde",
- "sp-arithmetic 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-wasm-builder-runner 2.0.0",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,30 +482,18 @@ name = "frame-benchmarking"
 version = "3.1.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
- "frame-support 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "frame-system 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "frame-support",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "sp-api",
- "sp-io 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime-interface 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-storage 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073f7bef18421362441a1708f8528e442234954611f95bdc554b313fb321948e"
-dependencies = [
- "parity-scale-codec",
- "serde",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
@@ -551,35 +503,8 @@ source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "frame-support"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e521e6214615bd82ba6b5fc7fd40a9cc14fdeb40f83da5eba12aa2f8179fb8"
-dependencies = [
- "bitflags",
- "frame-metadata 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support-procedural 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-trait-for-tuples",
- "log",
- "once_cell",
- "parity-scale-codec",
- "paste",
- "serde",
- "smallvec",
- "sp-arithmetic 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-staking 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-std",
 ]
 
 [[package]]
@@ -588,8 +513,8 @@ version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "bitflags",
- "frame-metadata 13.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "frame-support-procedural 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "frame-metadata",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
  "once_cell",
@@ -597,28 +522,15 @@ dependencies = [
  "paste",
  "serde",
  "smallvec",
- "sp-arithmetic 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-inherents 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-io 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-staking 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-state-machine 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-tracing 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2668e24cbaba7f0e91d0c92a94bd1ae425a942608ad0b775db32477f5df4da9e"
-dependencies = [
- "Inflector",
- "frame-support-procedural-tools 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2",
- "quote",
- "syn",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -627,20 +539,7 @@ version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "Inflector",
- "frame-support-procedural-tools 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f88cfd111e004590f4542b75e6d3302137b9067d7e7219e4ac47a535c3b5c1"
-dependencies = [
- "frame-support-procedural-tools-derive 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-crate 0.1.5",
+ "frame-support-procedural-tools",
  "proc-macro2",
  "quote",
  "syn",
@@ -651,7 +550,7 @@ name = "frame-support-procedural-tools"
 version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
- "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
@@ -661,17 +560,6 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79285388b120ac96c15a791c56b26b9264f7231324fbe0fd05026acd92bf2e6a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "proc-macro2",
@@ -682,35 +570,18 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fedbff05d665c00bf4e089b4377fcb15b8bd37ebc3e5fc06665474cf6e25d7"
-dependencies = [
- "frame-support 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "serde",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "frame-system"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
- "frame-support 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "frame-support",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "serde",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-io 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-version 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
@@ -1305,28 +1176,51 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41aaeaf084e594273f82bcbf96416ef1fcab602e15dd1df04b9930eceb2eb518"
-dependencies = [
- "frame-support 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "frame-benchmarking",
- "frame-support 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "frame-system 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-example"
+version = "0.0.1"
+dependencies = [
+ "chainbridge",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-example-erc721",
+ "parity-scale-codec",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "substrate-wasm-builder-runner",
+]
+
+[[package]]
+name = "pallet-example-erc721"
+version = "0.0.1"
+dependencies = [
+ "chainbridge",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "substrate-wasm-builder-runner",
 ]
 
 [[package]]
@@ -1884,11 +1778,11 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-state-machine 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-version 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-version",
  "thiserror",
 ]
 
@@ -1907,40 +1801,13 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52e2e6d43036b97c4fce1ed87c5262c1ffdc78c655ada4d3024a3f8094bdd2c"
-dependencies = [
- "parity-scale-codec",
- "serde",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-io 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f1c69966c192d1dee8521f0b29ece2b14db07b9b44d801a94e295234761645"
-dependencies = [
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "serde",
- "sp-debug-derive 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -1952,59 +1819,14 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "serde",
- "sp-debug-derive 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-debug-derive",
+ "sp-std",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbc8d4e9b8a7d5819ed26f1374017bb32833ef4890e4ff065e1da30669876bc"
-dependencies = [
- "base58",
- "blake2-rfc",
- "byteorder",
- "dyn-clonable",
- "ed25519-dalek",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "hex",
- "impl-serde",
- "lazy_static",
- "libsecp256k1",
- "log",
- "merlin",
- "num-traits",
- "parity-scale-codec",
- "parity-util-mem",
- "parking_lot 0.11.1",
- "primitive-types",
- "rand 0.7.3",
- "regex",
- "schnorrkel",
- "secrecy",
- "serde",
- "sha2 0.9.5",
- "sp-debug-derive 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-bip39",
- "thiserror",
- "tiny-bip39",
- "tiny-keccak",
- "twox-hash",
- "wasmi",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "base58",
@@ -2032,11 +1854,11 @@ dependencies = [
  "secrecy",
  "serde",
  "sha2 0.9.5",
- "sp-debug-derive 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-externalities 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime-interface 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-storage 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
@@ -2049,17 +1871,6 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80275f23b4e7ba8f54dec5f90f016530e7307d2ee9445f617ab986cbe97f31e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "proc-macro2",
@@ -2070,37 +1881,12 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fdc625f8c7b13b9a136d334888b21b5743d2081cb666cb03efca1dc9b8f74d1"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.9.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-storage 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2542380b535c6941502a0a3069a657eb5abb70fd67b11afa164d4a4b038ba73a"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.11.1",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
@@ -2111,40 +1897,15 @@ dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fd69f0a6e91bedc2fb1c5cc3689c212474b6c918274cb4cb14dbbe3c428c14"
-dependencies = [
- "futures",
- "hash-db",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "parking_lot 0.11.1",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-keystore 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "futures",
@@ -2153,35 +1914,18 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-externalities 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-keystore 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime-interface 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-state-machine 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-tracing 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-trie 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-wasm-interface 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie",
+ "sp-wasm-interface",
  "tracing",
  "tracing-core",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6ccd2baf189112355338e8b224dc513cd239b974dbd717f12b3dc7a7248c3b"
-dependencies = [
- "async-trait",
- "derive_more",
- "futures",
- "merlin",
- "parity-scale-codec",
- "parking_lot 0.11.1",
- "schnorrkel",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2196,8 +1940,8 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "schnorrkel",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-externalities 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-core",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -2212,40 +1956,9 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54702e109f1c8a870dd4065a497d2612d42cec5817126e96cc0658c5ea975784"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "backtrace",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa4b353b76f04616dbdb8d269d58dcac47acb31c006d3b70e7b64233e68695e"
-dependencies = [
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "parity-util-mem",
- "paste",
- "rand 0.7.3",
- "serde",
- "sp-application-crypto 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2262,29 +1975,11 @@ dependencies = [
  "paste",
  "rand 0.7.3",
  "serde",
- "sp-application-crypto 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-arithmetic 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-io 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5c88b4bc8d607e4e2ff767a85db58cf7101f3dd6064f06929342ea67fe8fb"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface-proc-macro 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -2295,26 +1990,13 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-runtime-interface-proc-macro 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-storage 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-tracing 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-wasm-interface 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a6c7c2251512c9e533d15db8a863b06ece1cbee778130dd9adbe44b6b39aa9"
-dependencies = [
- "Inflector",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2332,45 +2014,11 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc729eb10f8809c61a1fe439ac118a4413de004aaf863003ee8752ac0b596e73"
-dependencies = [
- "parity-scale-codec",
- "sp-runtime 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sp-staking"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fa4143e58e9130f726d4e8a9b86f3530a8bd19a2eedcdcf4af205f4b5a6d4f"
-dependencies = [
- "hash-db",
- "log",
- "num-traits",
- "parity-scale-codec",
- "parking_lot 0.11.1",
- "rand 0.7.3",
- "smallvec",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-panic-handler 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "trie-db",
- "trie-root",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -2385,11 +2033,11 @@ dependencies = [
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-externalities 0.9.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-panic-handler 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-trie 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-std",
+ "sp-trie",
  "thiserror",
  "tracing",
  "trie-db",
@@ -2399,27 +2047,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35391ea974fa5ee869cb094d5b437688fbf3d8127d64d1b9fed5822a1ed39b12"
-
-[[package]]
-name = "sp-std"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
-
-[[package]]
-name = "sp-storage"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86af458d4a0251c490cdde9dcaaccb88d398f3b97ac6694cdd49ed9337e6b961"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "sp-storage"
@@ -2430,22 +2058,8 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567382d8d4e14fb572752863b5cd57a78f9e9a6583332b590b726f061f3ea957"
-dependencies = [
- "log",
- "parity-scale-codec",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
@@ -2460,7 +2074,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-std",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2469,43 +2083,15 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85b7f745da41ef825c6f7b93f1fdc897b03df94a4884adfbb70fbcd0aed1298"
-dependencies = [
- "hash-db",
- "memory-db",
- "parity-scale-codec",
- "sp-core 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-db",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-core",
+ "sp-std",
  "trie-db",
  "trie-root",
-]
-
-[[package]]
-name = "sp-version"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbeffa538a13d715d30e01d57a2636ba32845b737a29a3ea32403576588222e7"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "serde",
- "sp-runtime 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2516,8 +2102,8 @@ dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "serde",
- "sp-runtime 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-runtime",
+ "sp-std",
  "sp-version-proc-macro",
 ]
 
@@ -2536,23 +2122,11 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b214e125666a6416cf30a70cc6a5dacd34a4e5197f8a3d479f714af7e1dc7a47"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-std 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "3.0.0"
 source = "git+https://github.com/centrifuge/substrate.git?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std 3.0.0 (git+https://github.com/centrifuge/substrate.git?branch=master)",
+ "sp-std",
  "wasmi",
 ]
 
@@ -2584,12 +2158,6 @@ dependencies = [
  "sha2 0.8.2",
  "zeroize",
 ]
-
-[[package]]
-name = "substrate-wasm-builder-runner"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cab12167e32b38a62c5ea5825aa0874cde315f907a46aad2b05aa8ef3d862f"
 
 [[package]]
 name = "substrate-wasm-builder-runner"

--- a/chainbridge/Cargo.toml
+++ b/chainbridge/Cargo.toml
@@ -7,19 +7,19 @@ edition = '2018'
 [dependencies]
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.101", optional = true }
+serde = { version = "1.0.102", optional = true }
 
 # primitives
-sp-io = { branch = "master", git = "https://github.com/centrifuge/substrate", default-features = false }
-sp-core = { branch = "master", git = "https://github.com/centrifuge/substrate.git", default-features = false }
-sp-runtime = { branch = "master", git = "https://github.com/centrifuge/substrate.git", default-features = false }
-sp-std = { branch = "master", git = "https://github.com/centrifuge/substrate", default-features = false }
+sp-io = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+sp-core = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+sp-runtime = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+sp-std = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
 
 # frame dependencies
-frame-support = { branch = "master", git = "https://github.com/centrifuge/substrate.git", default-features = false }
-frame-system = { branch = "master", git = "https://github.com/centrifuge/substrate.git", default-features = false }
+frame-support = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+frame-system = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 
-pallet-balances = { branch = "master", git = "https://github.com/centrifuge/substrate.git", default-features = false }
+pallet-balances = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "3.0.0", package = "substrate-wasm-builder-runner"}

--- a/chainbridge/Cargo.toml
+++ b/chainbridge/Cargo.toml
@@ -18,7 +18,6 @@ sp-std = { git = "https://github.com/centrifuge/substrate", default-features = f
 # frame dependencies
 frame-support = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 frame-system = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
-
 pallet-balances = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 
 [build-dependencies]

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -190,6 +190,7 @@ pub mod pallet {
         
         /// The identifier for this chain.
         /// This must be unique and must not collide with existing IDs within a set of bridged chains.
+        #[pallet::constant]
         type ChainId: Get<ChainId>;
 
         /// Constant configuration parameter to store the module identifier for the pallet.
@@ -496,8 +497,7 @@ pub mod pallet {
         /// # <weight>
         /// - weight of proposed call, regardless of whether execution is performed
         /// # </weight>
-//        #[weight = (call.get_dispatch_info().weight + 195_000_000, call.get_dispatch_info().class, Pays::Yes)]
-        #[pallet::weight(<T as Config>::WeightInfo::acknowledge_proposal())]
+        #[pallet::weight(<T as Config>::WeightInfo::acknowledge_proposal(call.get_dispatch_info().weight))]
         pub fn acknowledge_proposal(
             origin: OriginFor<T>,
             nonce: DepositNonce, 
@@ -542,8 +542,7 @@ pub mod pallet {
         /// # <weight>
         /// - weight of proposed call, regardless of whether execution is performed
         /// # </weight>
-//        #[weight = (prop.get_dispatch_info().weight + 195_000_000, proposal.get_dispatch_info().class, Pays::Yes)]
-        #[pallet::weight(<T as Config>::WeightInfo::eval_vote_state())]
+        #[pallet::weight(<T as Config>::WeightInfo::eval_vote_state(proposal.get_dispatch_info().weight))]
         pub fn eval_vote_state(
             origin: OriginFor<T>,
             nonce: DepositNonce, 

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -84,7 +84,7 @@ mod mock;
 mod tests;
 
 // Pallet types and traits
-mod types;
+pub mod types;
 mod traits;
 
 // Pallet extrinsics weight information
@@ -262,7 +262,7 @@ pub mod pallet {
         OptionQuery
     >;
 
-    // Default relayer threshold value for [`RelayerThreshold`] storage item
+    // Default (or initial) value for [`RelayerThreshold`] storage item
 	#[pallet::type_value]
 	pub fn OnRelayerThresholdEmpty<T: Config>() -> u32 {
 		DEFAULT_RELAYER_THRESHOLD
@@ -406,7 +406,7 @@ pub mod pallet {
         /// # <weight>
         /// - O(1) lookup and insert
         /// # </weight>
-        #[pallet::weight(<T as Config>::WeightInfo::set_threshold())]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::set_threshold())]
         pub fn set_threshold(
             origin: OriginFor<T>,
             threshold: u32
@@ -420,7 +420,7 @@ pub mod pallet {
         /// # <weight>
         /// - O(1) write
         /// # </weight>
-        #[pallet::weight(<T as Config>::WeightInfo::set_resource())]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::set_resource())]
         pub fn set_resource(
             origin: OriginFor<T>,
             id: ResourceId, 
@@ -452,7 +452,7 @@ pub mod pallet {
         /// # <weight>
         /// - O(1) lookup and insert
         /// # </weight>
-        #[pallet::weight(<T as Config>::WeightInfo::whitelist_chain())]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::whitelist_chain())]
         pub fn whitelist_chain(
             origin: OriginFor<T>,
             id: ChainId
@@ -480,7 +480,7 @@ pub mod pallet {
         /// # <weight>
         /// - O(1) lookup and removal
         /// # </weight>
-        #[pallet::weight(<T as Config>::WeightInfo::remove_relayer())]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::remove_relayer())]
         pub fn remove_relayer(
             origin: OriginFor<T>,
             account_id: T::AccountId
@@ -497,7 +497,7 @@ pub mod pallet {
         /// # <weight>
         /// - weight of proposed call, regardless of whether execution is performed
         /// # </weight>
-        #[pallet::weight(<T as Config>::WeightInfo::acknowledge_proposal(call.get_dispatch_info().weight))]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::acknowledge_proposal(call.get_dispatch_info().weight))]
         pub fn acknowledge_proposal(
             origin: OriginFor<T>,
             nonce: DepositNonce, 
@@ -518,7 +518,7 @@ pub mod pallet {
         /// # <weight>
         /// - Fixed, since execution of proposal should not be included
         /// # </weight>
-        #[pallet::weight(<T as Config>::WeightInfo::reject_proposal())]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::reject_proposal())]
         pub fn reject_proposal(
             origin: OriginFor<T>,
             nonce: DepositNonce, 
@@ -542,7 +542,7 @@ pub mod pallet {
         /// # <weight>
         /// - weight of proposed call, regardless of whether execution is performed
         /// # </weight>
-        #[pallet::weight(<T as Config>::WeightInfo::eval_vote_state(proposal.get_dispatch_info().weight))]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::eval_vote_state(proposal.get_dispatch_info().weight))]
         pub fn eval_vote_state(
             origin: OriginFor<T>,
             nonce: DepositNonce, 
@@ -820,7 +820,7 @@ impl<T: Config> Pallet<T> {
     pub fn transfer_generic(
         dest_id: ChainId,
         resource_id: ResourceId,
-        metadata: Vec<u8>,
+        metadata: Vec<u8>
     ) -> DispatchResult {
         ensure!(
             Self::chain_whitelisted(dest_id),

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -1,8 +1,99 @@
-// Ensure we're `no_std` when compiling for Wasm.
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! # Pallet for bridging Polkadot Substrate and Ethereum chains.
+//!
+//! This pallet implement a general-purpose bridge to pass arbitrary messages 
+//! Polkadot Substrate Chain and Ethereum or any other target network.
+//!
+//! - [`Config`]
+//! - [`Call`]
+//! - [`Pallet`]
+//!
+//! ## Overview
+//! This pallet is used for bridging chains.
+//!
+//! ## Terminology
+//! 
+//! ## Usage
+//!
+//! ## Interface
+//!
+//! ### Supported Origins
+//!
+//! Signed origin is valid.
+//!
+//! ### Types
+//!
+//! ### Events
+//!
+//!
+//! ### Errors
+//!
+//! ### Dispatchable Functions
+//!
+//! Callable functions (or extrinsics), also considered as transactions, materialize the
+//! pallet contract. Here's the callable functions implemented in this module:
+//!
+//! 
+//! ### Public Functions
+//!
+//! ## Genesis Configuration
+//! This pallet depends on the [`GenesisConfig`]. The following fields are added to
+//! the genesis configuration, that are not associated with specific storage values:
+//!
+//! ## Related Pallets
+//! This pallet is tightly coupled to the following pallets:
+//! - Substrate FRAME's [`balances` pallet](https://github.com/paritytech/substrate/tree/master/frame/balances).
+//! - Centrifuge Chain [`bridge` pallet](https://github.com/centrifuge/centrifuge-chain/tree/master/pallets/bridge).
+//! - Centrifuge Chain [`bridge_mapping` pallet](https://github.com/centrifuge/centrifuge-chain/tree/master/pallets/bridge-mapping).
+//!
+//! ## References
+//! - [Substrate FRAME v2 attribute macros](https://crates.parity.io/frame_support/attr.pallet.html).
+//! 
+//! ## Credits
+//! The Centrifugians Tribe <tribe@centrifuge.io>
+//!
+//! ## License
+//! GNU General Public License, Version 3, 29 June 2007 <https://www.gnu.org/licenses/gpl-3.0.html>
+
+
+// Ensure we're `no_std` when compiling for WebAssembly.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Mock runtime and unit test cases
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+// Pallet types and traits
+mod types;
+mod traits;
+
+// Pallet extrinsics weight information
+mod weights;
+
+// Substrate primitives
+use codec::EncodeLike;
+
 use frame_support::{
-    decl_error, decl_event, decl_module, decl_storage,
     dispatch::DispatchResult,
     ensure,
     PalletId,
@@ -10,124 +101,130 @@ use frame_support::{
         EnsureOrigin, 
         Get,
     },
-    weights::{
-        GetDispatchInfo, 
-        Pays,
-    },
+    weights::GetDispatchInfo,
     Parameter,
 };
 
+use frame_system::{
+    ensure_root, 
+    ensure_signed
+};
 
-use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_core::U256;
-use sp_runtime::traits::{AccountIdConversion, Dispatchable};
-use sp_runtime::RuntimeDebug;
+
+use sp_runtime::traits::{
+    AccountIdConversion, 
+    Dispatchable
+};
+
 use sp_std::prelude::*;
 
-use codec::{Decode, Encode, EncodeLike};
+use crate::{
+    traits::WeightInfo,
+    types::{
+        ChainId, 
+        DepositNonce,
+        ProposalStatus,
+        ProposalVotes,
+        ResourceId,
+    }
+};
 
-mod mock;
-mod tests;
+// Re-export pallet components in crate namespace (for runtime construction)
+pub use pallet::*;
+
+
+// ----------------------------------------------------------------------------
+// Constants definition
+// ----------------------------------------------------------------------------
 
 const DEFAULT_RELAYER_THRESHOLD: u32 = 1;
-const MODULE_ID: PalletId = PalletId(*b"cb/bridg");
 
-pub type ChainId = u8;
-pub type DepositNonce = u64;
-pub type ResourceId = [u8; 32];
 
-/// Helper function to concatenate a chain ID and some bytes to produce a resource ID.
-/// The common format is (31 bytes unique ID + 1 byte chain ID).
-pub fn derive_resource_id(chain: u8, id: &[u8]) -> ResourceId {
-    let mut r_id: ResourceId = [0; 32];
-    r_id[31] = chain; // last byte is chain id
-    let range = if id.len() > 31 { 31 } else { id.len() }; // Use at most 31 bytes
-    for i in 0..range {
-        r_id[30 - i] = id[range - 1 - i]; // Ensure left padding for eth compatibility
+// ----------------------------------------------------------------------------
+// Pallet module
+// ----------------------------------------------------------------------------
+
+// Chain bridge pallet module
+//
+// The name of the pallet is provided by `construct_runtime` and is used as
+// the unique identifier for the pallet's storage. It is not defined in the 
+// pallet itself.
+#[frame_support::pallet]
+pub mod pallet {
+
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+    // Bridge pallet type declaration.
+    //
+    // This structure is a placeholder for traits and functions implementation
+    // for the pallet.
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
+
+
+    // ------------------------------------------------------------------------
+    // Pallet configuration
+    // ------------------------------------------------------------------------
+
+    /// Chain bridge pallet's configuration trait.
+    ///
+    /// Associated types and constants are declared in this trait. If the pallet
+    /// depends on other super-traits, the latter must be added to this trait, 
+    /// such as, in this case, [`chainbridge::Config`] super-trait, for instance. 
+    /// Note that [`frame_system::Config`] must always be included.
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+
+        /// Associated type for Event enum
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        /// Origin used to administer the pallet
+        type AdminOrigin: EnsureOrigin<Self::Origin>;
+        
+        /// Proposed dispatchable call
+        type Proposal: Parameter + Dispatchable<Origin = Self::Origin> + EncodeLike + GetDispatchInfo;
+        
+        /// The identifier for this chain.
+        /// This must be unique and must not collide with existing IDs within a set of bridged chains.
+        type ChainId: Get<ChainId>;
+
+        /// Constant configuration parameter to store the module identifier for the pallet.
+        ///
+        /// The module identifier may be of the form ```PalletId(*b"chnbrdge")``` and set
+        /// using the [`parameter_types`](https://substrate.dev/docs/en/knowledgebase/runtime/macros#parameter_types) 
+        // macro in the [`runtime/lib.rs`] file.
+        #[pallet::constant]
+        type PalletId: Get<PalletId>;
+
+        #[pallet::constant]
+        type ProposalLifetime: Get<Self::BlockNumber>;
+
+        /// Weight information for extrinsics in this pallet
+        type WeightInfo: WeightInfo;
     }
-    return r_id;
-}
 
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum ProposalStatus {
-    Initiated,
-    Approved,
-    Rejected,
-}
 
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub struct ProposalVotes<AccountId, BlockNumber> {
-    pub votes_for: Vec<AccountId>,
-    pub votes_against: Vec<AccountId>,
-    pub status: ProposalStatus,
-    pub expiry: BlockNumber,
-}
+    // ------------------------------------------------------------------------
+    // Pallet events
+    // ------------------------------------------------------------------------
 
-impl<A: PartialEq, B: PartialOrd + Default> ProposalVotes<A, B> {
-    /// Attempts to mark the proposal as approve or rejected.
-    /// Returns true if the status changes from active.
-    fn try_to_complete(&mut self, threshold: u32, total: u32) -> ProposalStatus {
-        if self.votes_for.len() >= threshold as usize {
-            self.status = ProposalStatus::Approved;
-            ProposalStatus::Approved
-        } else if total >= threshold && self.votes_against.len() as u32 + threshold > total {
-            self.status = ProposalStatus::Rejected;
-            ProposalStatus::Rejected
-        } else {
-            ProposalStatus::Initiated
-        }
-    }
-
-    /// Returns true if the proposal has been rejected or approved, otherwise false.
-    fn is_complete(&self) -> bool {
-        self.status != ProposalStatus::Initiated
-    }
-
-    /// Returns true if `who` has voted for or against the proposal
-    fn has_voted(&self, who: &A) -> bool {
-        self.votes_for.contains(&who) || self.votes_against.contains(&who)
-    }
-
-    /// Return true if the expiry time has been reached
-    fn is_expired(&self, now: B) -> bool {
-        self.expiry <= now
-    }
-}
-
-impl<AccountId, BlockNumber: Default> Default for ProposalVotes<AccountId, BlockNumber> {
-    fn default() -> Self {
-        Self {
-            votes_for: Vec::new(),
-            votes_against: Vec::new(),
-            status: ProposalStatus::Initiated,
-            expiry: BlockNumber::default(),
-        }
-    }
-}
-
-pub trait Config: system::Config {
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-    /// Origin used to administer the pallet
-    type AdminOrigin: EnsureOrigin<Self::Origin>;
-    /// Proposed dispatchable call
-    type Proposal: Parameter + Dispatchable<Origin = Self::Origin> + EncodeLike + GetDispatchInfo;
-    /// The identifier for this chain.
-    /// This must be unique and must not collide with existing IDs within a set of bridged chains.
-    type ChainId: Get<ChainId>;
-
-    type ProposalLifetime: Get<Self::BlockNumber>;
-}
-
-decl_event! {
-    pub enum Event<T> where <T as frame_system::Config>::AccountId {
+    // The macro generates event metadata and derive Clone, Debug, Eq, PartialEq and Codec
+    #[pallet::event]
+    // The macro generates a function on Pallet to deposit an event
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
         /// Vote threshold has changed (new_threshold)
         RelayerThresholdChanged(u32),
         /// Chain now available for transfers (chain_id)
         ChainWhitelisted(ChainId),
         /// Relayer added to set
-        RelayerAdded(AccountId),
+        RelayerAdded(T::AccountId),
         /// Relayer removed from set
-        RelayerRemoved(AccountId),
+        RelayerRemoved(T::AccountId),
         /// FunglibleTransfer is for relaying fungibles (dest_id, nonce, resource_id, amount, recipient, metadata)
         FungibleTransfer(ChainId, DepositNonce, ResourceId, U256, Vec<u8>),
         /// NonFungibleTransfer is for relaying NFTS (dest_id, nonce, resource_id, token_id, recipient, metadata)
@@ -135,9 +232,9 @@ decl_event! {
         /// GenericTransfer is for a generic data payload (dest_id, nonce, resource_id, metadata)
         GenericTransfer(ChainId, DepositNonce, ResourceId, Vec<u8>),
         /// Vote submitted in favour of proposal
-        VoteFor(ChainId, DepositNonce, AccountId),
+        VoteFor(ChainId, DepositNonce, T::AccountId),
         /// Vot submitted against proposal
-        VoteAgainst(ChainId, DepositNonce, AccountId),
+        VoteAgainst(ChainId, DepositNonce, T::AccountId),
         /// Voting successful for a proposal
         ProposalApproved(ChainId, DepositNonce),
         /// Voting rejected a proposal
@@ -147,10 +244,113 @@ decl_event! {
         /// Execution of call failed
         ProposalFailed(ChainId, DepositNonce),
     }
-}
 
-decl_error! {
-    pub enum Error for Module<T: Config> {
+
+    // ------------------------------------------------------------------------
+    // Pallet storage items
+    // ------------------------------------------------------------------------
+
+    /// All whitelisted chains and their respective transaction counts
+	#[pallet::storage]
+	#[pallet::getter(fn get_chains)]
+	pub(super) type ChainNonces<T: Config> = StorageMap<
+        _, 
+        Blake2_256, 
+        ChainId, 
+        DepositNonce, 
+        OptionQuery
+    >;
+
+    // Default relayer threshold value for [`RelayerThreshold`] storage item
+	#[pallet::type_value]
+	pub fn OnRelayerThresholdEmpty<T: Config>() -> u32 {
+		DEFAULT_RELAYER_THRESHOLD
+	}
+
+    /// Number of votes required for a proposal to execute
+	#[pallet::storage]
+	#[pallet::getter(fn get_relayer_threshold)]
+    pub(super) type RelayerThreshold<T: Config> = StorageValue<_, u32, ValueQuery, OnRelayerThresholdEmpty<T>>;
+
+    /// Tracks current relayer set
+	#[pallet::storage]
+	#[pallet::getter(fn get_relayers)]
+    pub(super) type Relayers<T: Config> = StorageMap<
+        _,
+        Blake2_256,
+        T::AccountId,
+        bool,
+        ValueQuery
+    >;
+
+    /// Number of relayers in set
+	#[pallet::storage]
+	#[pallet::getter(fn get_relayer_count)]
+	pub(super) type RelayerCount<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+    /// All known proposals.
+    /// The key is the hash of the call and the deposit ID, to ensure it's unique.
+	#[pallet::storage]
+	#[pallet::getter(fn get_votes)]
+    pub(super) type Votes<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_256,
+        ChainId,
+        Blake2_256,
+        (DepositNonce, T::Proposal),
+        ProposalVotes<T::AccountId, T::BlockNumber>,
+        OptionQuery
+    >;
+    
+    /// Utilized by the bridge software to map resource IDs to actual methods
+	#[pallet::storage]
+	#[pallet::getter(fn get_resources)]
+    pub(super) type Resources<T: Config> = StorageMap<
+        _,
+        Blake2_256,
+        ResourceId,
+        Vec<u8>,
+        OptionQuery
+    >;      
+    
+
+	// ------------------------------------------------------------------------
+	// Pallet genesis configuration
+	// ------------------------------------------------------------------------
+
+	// The genesis configuration type.
+	#[pallet::genesis_config]
+	pub struct GenesisConfig {}
+
+	// The default value for the genesis config type.
+	#[cfg(feature = "std")]
+	impl Default for GenesisConfig {
+		fn default() -> Self {
+			Self {}
+		}
+	}
+
+	// The build of genesis for the pallet.
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {}
+	}
+
+
+    // ------------------------------------------------------------------------
+    // Pallet lifecycle hooks
+    // ------------------------------------------------------------------------
+    
+    #[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+
+    // ------------------------------------------------------------------------
+    // Pallet errors
+    // ------------------------------------------------------------------------
+
+    #[pallet::error]
+    pub enum Error<T> {
         /// Relayer threshold not set
         ThresholdNotSet,
         /// Provided chain Id is not valid
@@ -182,43 +382,20 @@ decl_error! {
         /// Lifetime of proposal has been exceeded
         ProposalExpired,
     }
-}
 
-decl_storage! {
-    trait Store for Module<T: Config> as ChainBridge {
-        /// All whitelisted chains and their respective transaction counts
-        ChainNonces get(fn chains): map hasher(opaque_blake2_256) ChainId => Option<DepositNonce>;
 
-        /// Number of votes required for a proposal to execute
-        RelayerThreshold get(fn relayer_threshold): u32 = DEFAULT_RELAYER_THRESHOLD;
+	// ------------------------------------------------------------------------
+	// Pallet dispatchable functions
+	// ------------------------------------------------------------------------
 
-        /// Tracks current relayer set
-        pub Relayers get(fn relayers): map hasher(opaque_blake2_256) T::AccountId => bool;
-
-        /// Number of relayers in set
-        pub RelayerCount get(fn relayer_count): u32;
-
-        /// All known proposals.
-        /// The key is the hash of the call and the deposit ID, to ensure it's unique.
-        pub Votes get(fn votes):
-            double_map hasher(opaque_blake2_256) ChainId, hasher(opaque_blake2_256) (DepositNonce, T::Proposal)
-            => Option<ProposalVotes<T::AccountId, T::BlockNumber>>;
-
-        /// Utilized by the bridge software to map resource IDs to actual methods
-        pub Resources get(fn resources):
-            map hasher(opaque_blake2_256) ResourceId => Option<Vec<u8>>
-    }
-}
-
-decl_module! {
-    pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        type Error = Error<T>;
-
-        const ChainIdentity: ChainId = T::ChainId::get();
-        const ProposalLifetime: T::BlockNumber = T::ProposalLifetime::get();
-        const BridgeAccountId: T::AccountId = MODULE_ID.into_account();
-
-        fn deposit_event() = default;
+	// Declare Call struct and implement dispatchable (or callable) functions.
+	//
+	// Dispatchable functions are transactions modifying the state of the chain. They
+	// are also called extrinsics are constitute the pallet's public interface.
+	// Note that each parameter used in functions must implement `Clone`, `Debug`,
+	// `Eq`, `PartialEq` and `Codec` traits.
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 
         /// Sets the vote threshold for proposals.
         ///
@@ -228,8 +405,11 @@ decl_module! {
         /// # <weight>
         /// - O(1) lookup and insert
         /// # </weight>
-        #[weight = 195_000_000]
-        pub fn set_threshold(origin, threshold: u32) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::set_threshold())]
+        pub fn set_threshold(
+            origin: OriginFor<T>,
+            threshold: u32
+        ) -> DispatchResult {
             Self::ensure_admin(origin)?;
             Self::set_relayer_threshold(threshold)
         }
@@ -239,8 +419,12 @@ decl_module! {
         /// # <weight>
         /// - O(1) write
         /// # </weight>
-        #[weight = 195_000_000]
-        pub fn set_resource(origin, id: ResourceId, method: Vec<u8>) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::set_resource())]
+        pub fn set_resource(
+            origin: OriginFor<T>,
+            id: ResourceId, 
+            method: Vec<u8>
+        ) -> DispatchResult {
             Self::ensure_admin(origin)?;
             Self::register_resource(id, method)
         }
@@ -253,8 +437,11 @@ decl_module! {
         /// # <weight>
         /// - O(1) removal
         /// # </weight>
-        #[weight = 195_000_000]
-        pub fn remove_resource(origin, id: ResourceId) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::remove_resource())]
+        pub fn remove_resource(
+            origin: OriginFor<T>,
+            id: ResourceId
+        ) -> DispatchResult {
             Self::ensure_admin(origin)?;
             Self::unregister_resource(id)
         }
@@ -264,8 +451,11 @@ decl_module! {
         /// # <weight>
         /// - O(1) lookup and insert
         /// # </weight>
-        #[weight = 195_000_000]
-        pub fn whitelist_chain(origin, id: ChainId) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::whitelist_chain())]
+        pub fn whitelist_chain(
+            origin: OriginFor<T>,
+            id: ChainId
+        ) -> DispatchResult {
             Self::ensure_admin(origin)?;
             Self::whitelist(id)
         }
@@ -275,8 +465,11 @@ decl_module! {
         /// # <weight>
         /// - O(1) lookup and insert
         /// # </weight>
-        #[weight = 195_000_000]
-        pub fn add_relayer(origin, v: T::AccountId) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::add_relayer())]
+        pub fn add_relayer(
+            origin: OriginFor<T>,
+            v: T::AccountId
+        ) -> DispatchResult {
             Self::ensure_admin(origin)?;
             Self::register_relayer(v)
         }
@@ -286,10 +479,13 @@ decl_module! {
         /// # <weight>
         /// - O(1) lookup and removal
         /// # </weight>
-        #[weight = 195_000_000]
-        pub fn remove_relayer(origin, v: T::AccountId) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::remove_relayer())]
+        pub fn remove_relayer(
+            origin: OriginFor<T>,
+            account_id: T::AccountId
+        ) -> DispatchResult {
             Self::ensure_admin(origin)?;
-            Self::unregister_relayer(v)
+            Self::unregister_relayer(account_id)
         }
 
         /// Commits a vote in favour of the provided proposal.
@@ -300,8 +496,15 @@ decl_module! {
         /// # <weight>
         /// - weight of proposed call, regardless of whether execution is performed
         /// # </weight>
-        #[weight = (call.get_dispatch_info().weight + 195_000_000, call.get_dispatch_info().class, Pays::Yes)]
-        pub fn acknowledge_proposal(origin, nonce: DepositNonce, src_id: ChainId, r_id: ResourceId, call: Box<<T as Config>::Proposal>) -> DispatchResult {
+//        #[weight = (call.get_dispatch_info().weight + 195_000_000, call.get_dispatch_info().class, Pays::Yes)]
+        #[pallet::weight(<T as Config>::WeightInfo::acknowledge_proposal())]
+        pub fn acknowledge_proposal(
+            origin: OriginFor<T>,
+            nonce: DepositNonce, 
+            src_id: ChainId, 
+            r_id: ResourceId, 
+            call: Box<<T as Config>::Proposal>
+        ) -> DispatchResult {
             let who = ensure_signed(origin)?;
             ensure!(Self::is_relayer(&who), Error::<T>::MustBeRelayer);
             ensure!(Self::chain_whitelisted(src_id), Error::<T>::ChainNotWhitelisted);
@@ -315,8 +518,14 @@ decl_module! {
         /// # <weight>
         /// - Fixed, since execution of proposal should not be included
         /// # </weight>
-        #[weight = 195_000_000]
-        pub fn reject_proposal(origin, nonce: DepositNonce, src_id: ChainId, r_id: ResourceId, call: Box<<T as Config>::Proposal>) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::reject_proposal())]
+        pub fn reject_proposal(
+            origin: OriginFor<T>,
+            nonce: DepositNonce, 
+            src_id: ChainId, 
+            r_id: ResourceId, 
+            call: Box<<T as Config>::Proposal>
+        ) -> DispatchResult {
             let who = ensure_signed(origin)?;
             ensure!(Self::is_relayer(&who), Error::<T>::MustBeRelayer);
             ensure!(Self::chain_whitelisted(src_id), Error::<T>::ChainNotWhitelisted);
@@ -333,17 +542,41 @@ decl_module! {
         /// # <weight>
         /// - weight of proposed call, regardless of whether execution is performed
         /// # </weight>
-        #[weight = (prop.get_dispatch_info().weight + 195_000_000, prop.get_dispatch_info().class, Pays::Yes)]
-        pub fn eval_vote_state(origin, nonce: DepositNonce, src_id: ChainId, prop: Box<<T as Config>::Proposal>) -> DispatchResult {
+//        #[weight = (prop.get_dispatch_info().weight + 195_000_000, proposal.get_dispatch_info().class, Pays::Yes)]
+        #[pallet::weight(<T as Config>::WeightInfo::eval_vote_state())]
+        pub fn eval_vote_state(
+            origin: OriginFor<T>,
+            nonce: DepositNonce, 
+            src_id: ChainId, 
+            proposal: Box<<T as Config>::Proposal>
+        ) -> DispatchResult {
             ensure_signed(origin)?;
 
-            Self::try_resolve_proposal(nonce, src_id, prop)
+            Self::try_resolve_proposal(nonce, src_id, proposal)
         }
     }
-}
+} // end of 'pallet' module
 
-impl<T: Config> Module<T> {
+
+// ----------------------------------------------------------------------------
+// Pallet implementation block
+// ----------------------------------------------------------------------------
+
+// Chain bridge pallet implementation block.
+//
+// This main implementation block contains two categories of functions, namely:
+// - Public functions: These are functions that are `pub` and generally fall into
+//   inspector functions that do not write to storage and operation functions that do.
+// - Private functions: These are private helpers or utilities that cannot be called
+//   from other pallets.
+impl<T: Config> Pallet<T> {
     // *** Utility methods ***
+
+    /// Provides an AccountId for the pallet.
+    /// This is used both as an origin check and deposit/withdrawal account.
+	pub fn account_id() -> T::AccountId {
+		T::PalletId::get().into_account()
+	}
 
     pub fn ensure_admin(o: T::Origin) -> DispatchResult {
         T::AdminOrigin::try_origin(o)
@@ -354,29 +587,24 @@ impl<T: Config> Module<T> {
 
     /// Checks if who is a relayer
     pub fn is_relayer(who: &T::AccountId) -> bool {
-        Self::relayers(who)
+        Self::get_relayers(who)
     }
 
-    /// Provides an AccountId for the pallet.
-    /// This is used both as an origin check and deposit/withdrawal account.
-    pub fn account_id() -> T::AccountId {
-        MODULE_ID.into_account()
-    }
 
     /// Asserts if a resource is registered
     pub fn resource_exists(id: ResourceId) -> bool {
-        return Self::resources(id) != None;
+        return Self::get_resources(id) != None;
     }
 
     /// Checks if a chain exists as a whitelisted destination
     pub fn chain_whitelisted(id: ChainId) -> bool {
-        return Self::chains(id) != None;
+        return Self::get_chains(id) != None;
     }
 
     /// Increments the deposit nonce for the specified chain ID
     fn bump_nonce(id: ChainId) -> DepositNonce {
-        let nonce = Self::chains(id).unwrap_or_default() + 1;
-        <ChainNonces>::insert(id, nonce);
+        let nonce = Self::get_chains(id).unwrap_or_default() + 1;
+        <ChainNonces<T>>::insert(id, nonce);
         nonce
     }
 
@@ -385,20 +613,20 @@ impl<T: Config> Module<T> {
     /// Set a new voting threshold
     pub fn set_relayer_threshold(threshold: u32) -> DispatchResult {
         ensure!(threshold > 0, Error::<T>::InvalidThreshold);
-        <RelayerThreshold>::put(threshold);
-        Self::deposit_event(RawEvent::RelayerThresholdChanged(threshold));
+        <RelayerThreshold<T>>::put(threshold);
+        Self::deposit_event(Event::RelayerThresholdChanged(threshold));
         Ok(())
     }
 
     /// Register a method for a resource Id, enabling associated transfers
     pub fn register_resource(id: ResourceId, method: Vec<u8>) -> DispatchResult {
-        <Resources>::insert(id, method);
+        <Resources<T>>::insert(id, method);
         Ok(())
     }
 
     /// Removes a resource ID, disabling associated transfer
     pub fn unregister_resource(id: ResourceId) -> DispatchResult {
-        <Resources>::remove(id);
+        <Resources<T>>::remove(id);
         Ok(())
     }
 
@@ -411,8 +639,8 @@ impl<T: Config> Module<T> {
             !Self::chain_whitelisted(id),
             Error::<T>::ChainAlreadyWhitelisted
         );
-        <ChainNonces>::insert(&id, 0);
-        Self::deposit_event(RawEvent::ChainWhitelisted(id));
+        <ChainNonces<T>>::insert(&id, 0);
+        Self::deposit_event(Event::ChainWhitelisted(id));
         Ok(())
     }
 
@@ -423,9 +651,9 @@ impl<T: Config> Module<T> {
             Error::<T>::RelayerAlreadyExists
         );
         <Relayers<T>>::insert(&relayer, true);
-        <RelayerCount>::mutate(|i| *i += 1);
+        <RelayerCount<T>>::mutate(|i| *i += 1);
 
-        Self::deposit_event(RawEvent::RelayerAdded(relayer));
+        Self::deposit_event(Event::RelayerAdded(relayer));
         Ok(())
     }
 
@@ -433,8 +661,8 @@ impl<T: Config> Module<T> {
     pub fn unregister_relayer(relayer: T::AccountId) -> DispatchResult {
         ensure!(Self::is_relayer(&relayer), Error::<T>::RelayerInvalid);
         <Relayers<T>>::remove(&relayer);
-        <RelayerCount>::mutate(|i| *i -= 1);
-        Self::deposit_event(RawEvent::RelayerRemoved(relayer));
+        <RelayerCount<T>>::mutate(|i| *i -= 1);
+        Self::deposit_event(Event::RelayerRemoved(relayer));
         Ok(())
     }
 
@@ -465,10 +693,10 @@ impl<T: Config> Module<T> {
 
         if in_favour {
             votes.votes_for.push(who.clone());
-            Self::deposit_event(RawEvent::VoteFor(src_id, nonce, who.clone()));
+            Self::deposit_event(Event::VoteFor(src_id, nonce, who.clone()));
         } else {
             votes.votes_against.push(who.clone());
-            Self::deposit_event(RawEvent::VoteAgainst(src_id, nonce, who.clone()));
+            Self::deposit_event(Event::VoteAgainst(src_id, nonce, who.clone()));
         }
 
         <Votes<T>>::insert(src_id, (nonce, prop.clone()), votes.clone());
@@ -487,7 +715,7 @@ impl<T: Config> Module<T> {
             ensure!(!votes.is_complete(), Error::<T>::ProposalAlreadyComplete);
             ensure!(!votes.is_expired(now), Error::<T>::ProposalExpired);
 
-            let status = votes.try_to_complete(<RelayerThreshold>::get(), <RelayerCount>::get());
+            let status = votes.try_to_complete(Self::get_relayer_threshold(), Self::get_relayer_count());
             <Votes<T>>::insert(src_id, (nonce, prop.clone()), votes.clone());
 
             match status {
@@ -511,7 +739,7 @@ impl<T: Config> Module<T> {
         Self::try_resolve_proposal(nonce, src_id, prop)
     }
 
-    /// Commits a vote against the proposal and cancels it if more than (relayers.len() - threshold)
+    /// Commits a vote against the proposal and cancels it if more than (get_relayers.len() - threshold)
     /// votes against exist.
     fn vote_against(
         who: T::AccountId,
@@ -529,17 +757,17 @@ impl<T: Config> Module<T> {
         nonce: DepositNonce,
         call: Box<T::Proposal>,
     ) -> DispatchResult {
-        Self::deposit_event(RawEvent::ProposalApproved(src_id, nonce));
+        Self::deposit_event(Event::ProposalApproved(src_id, nonce));
         call.dispatch(frame_system::RawOrigin::Signed(Self::account_id()).into())
             .map(|_| ())
             .map_err(|e| e.error)?;
-        Self::deposit_event(RawEvent::ProposalSucceeded(src_id, nonce));
+        Self::deposit_event(Event::ProposalSucceeded(src_id, nonce));
         Ok(())
     }
 
     /// Cancels a proposal.
     fn cancel_execution(src_id: ChainId, nonce: DepositNonce) -> DispatchResult {
-        Self::deposit_event(RawEvent::ProposalRejected(src_id, nonce));
+        Self::deposit_event(Event::ProposalRejected(src_id, nonce));
         Ok(())
     }
 
@@ -555,7 +783,7 @@ impl<T: Config> Module<T> {
             Error::<T>::ChainNotWhitelisted
         );
         let nonce = Self::bump_nonce(dest_id);
-        Self::deposit_event(RawEvent::FungibleTransfer(
+        Self::deposit_event(Event::FungibleTransfer(
             dest_id,
             nonce,
             resource_id,
@@ -578,7 +806,7 @@ impl<T: Config> Module<T> {
             Error::<T>::ChainNotWhitelisted
         );
         let nonce = Self::bump_nonce(dest_id);
-        Self::deposit_event(RawEvent::NonFungibleTransfer(
+        Self::deposit_event(Event::NonFungibleTransfer(
             dest_id,
             nonce,
             resource_id,
@@ -600,7 +828,7 @@ impl<T: Config> Module<T> {
             Error::<T>::ChainNotWhitelisted
         );
         let nonce = Self::bump_nonce(dest_id);
-        Self::deposit_event(RawEvent::GenericTransfer(
+        Self::deposit_event(Event::GenericTransfer(
             dest_id,
             nonce,
             resource_id,
@@ -612,13 +840,27 @@ impl<T: Config> Module<T> {
 
 /// Simple ensure origin for the bridge account
 pub struct EnsureBridge<T>(sp_std::marker::PhantomData<T>);
-impl<T: Config> EnsureOrigin<T::Origin> for EnsureBridge<T> {
+
+impl<T: pallet::Config> EnsureOrigin<T::Origin> for EnsureBridge<T> {
     type Success = T::AccountId;
+
     fn try_origin(o: T::Origin) -> Result<Self::Success, T::Origin> {
-        let bridge_id = MODULE_ID.into_account();
+        let bridge_id = T::PalletId::get().into_account();
         o.into().and_then(|o| match o {
-            system::RawOrigin::Signed(who) if who == bridge_id => Ok(bridge_id),
+            frame_system::RawOrigin::Signed(who) if who == bridge_id => Ok(bridge_id),
             r => Err(T::Origin::from(r)),
         })
     }
+}
+
+/// Helper function to concatenate a chain ID and some bytes to produce a resource ID.
+/// The common format is (31 bytes unique ID + 1 byte chain ID).
+pub fn derive_resource_id(chain: u8, id: &[u8]) -> ResourceId {
+    let mut r_id: ResourceId = [0; 32];
+    r_id[31] = chain; // last byte is chain id
+    let range = if id.len() > 31 { 31 } else { id.len() }; // Use at most 31 bytes
+    for i in 0..range {
+        r_id[30 - i] = id[range - 1 - i]; // Ensure left padding for eth compatibility
+    }
+    return r_id;
 }

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -1,19 +1,142 @@
-#![cfg(test)]
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
 
-use super::*;
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
 
-use frame_support::{assert_ok, ord_parameter_types, parameter_types, weights::Weight};
-use frame_system::{self as system};
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Mocking runtime for testing the Substrate/Ethereum chains bridging pallet.
+//!
+//! The main components implemented in this mock module is a mock runtime
+//! and some helper functions.
+
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+use frame_support::{PalletId, assert_ok, parameter_types, traits::SortedMembers, weights::Weight};
+
+use frame_system::EnsureSignedBy;
+
 use sp_core::H256;
+
+use sp_io::TestExternalities;
+
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{
+        BlakeTwo256, 
+        IdentityLookup
+    },
     Perbill,
 };
 
-use crate::{self as bridge, Config};
-pub use pallet_balances as balances;
+use crate::{
+    self as pallet_chainbridge,
+    traits::WeightInfo,
+    types::ResourceId,
+};
 
+
+// ----------------------------------------------------------------------------
+// Types and constants declaration
+// ----------------------------------------------------------------------------
+type Balance = u64;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<MockRuntime>;
+type Block = frame_system::mocking::MockBlock<MockRuntime>;
+// TODO [ToZ] - Old type aliases
+//pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+//pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
+
+// Implement testing extrinsic weights for the pallet
+pub struct MockWeightInfo;
+impl WeightInfo for MockWeightInfo {
+
+    fn set_threshold() -> Weight {
+        0 as Weight
+    }
+
+    fn set_resource() -> Weight {
+        0 as Weight
+    }
+    
+    fn remove_resource() -> Weight {
+        0 as Weight
+    }
+
+    fn whitelist_chain() -> Weight {
+        0 as Weight    
+    }
+
+    fn add_relayer() -> Weight {
+        0 as Weight
+    }
+
+    fn remove_relayer() -> Weight {
+        0 as Weight
+    }
+
+    // #[weight = (call.get_dispatch_info().weight + 195_000_000, call.get_dispatch_info().class, Pays::Yes)]
+    fn acknowledge_proposal() -> Weight {
+        0 as Weight
+    }
+
+    fn reject_proposal() -> Weight {
+        0 as Weight
+    }
+
+    // #[weight = (prop.get_dispatch_info().weight + 195_000_000, prop.get_dispatch_info().class, Pays::Yes)]
+    fn eval_vote_state() -> Weight {
+        0 as Weight
+    }
+}
+
+// Constants definition
+pub const BRIDGE_ID: u64 = 5;
+pub(crate) const RELAYER_A: u64 = 0x2;
+pub(crate) const RELAYER_B: u64 = 0x3;
+pub(crate) const RELAYER_C: u64 = 0x4;
+pub(crate) const ENDOWED_BALANCE: u64 = 100_000_000;
+pub(crate) const TEST_THRESHOLD: u32 = 2;
+
+
+// ----------------------------------------------------------------------------
+// Mock runtime configuration
+// ----------------------------------------------------------------------------
+
+// Build mock runtime
+frame_support::construct_runtime!(
+
+    pub enum MockRuntime where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic
+    {
+        System: frame_system::{Pallet, Call, Event<T>},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+        ChainBridge: pallet_chainbridge::{Pallet, Call, Storage, Event<T>},
+    }
+);
+
+// Parameterize default test user identifier (with id 1)
+parameter_types! {
+    pub const TestUserId: u64 = 1;
+}
+
+impl SortedMembers<u64> for TestUserId{
+    fn sorted_members() -> Vec<u64> {
+        vec![1]
+    }
+}
+
+// Parameterize FRAME system pallet
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const MaximumBlockWeight: Weight = 1024;
@@ -22,7 +145,8 @@ parameter_types! {
     pub const MaxLocks: u32 = 100;
 }
 
-impl frame_system::Config for Test {
+// Implement FRAME system pallet configuration trait for the mock runtime
+impl frame_system::Config for MockRuntime {
     type BaseCallFilter = ();
     type Origin = Origin;
     type Call = Call;
@@ -48,101 +172,111 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
+// Parameterize FRAME balances pallet
 parameter_types! {
     pub const ExistentialDeposit: u64 = 1;
 }
 
-ord_parameter_types! {
-    pub const One: u64 = 1;
-}
-
-impl pallet_balances::Config for Test {
-    type Balance = u64;
+// Implement FRAME balances pallet configuration trait for the mock runtime
+impl pallet_balances::Config for MockRuntime {
+    type Balance = Balance;
     type DustRemoval = ();
     type Event = Event;
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
-    type MaxLocks = MaxLocks;
     type WeightInfo = ();
+    type MaxLocks = ();
 }
 
+// Parameterize chain bridge pallet
 parameter_types! {
-    pub const TestChainId: u8 = 5;
-    pub const ProposalLifetime: u64 = 50;
+    pub const ChainId: u8 = 5;
+    pub const ChainBridgePalletId: PalletId = PalletId(*b"chnbrdge");
+    pub const ProposalLifetime: u64 = 10;
 }
 
-impl Config for Test {
+// Implement chain bridge pallet configuration trait for the mock runtime
+impl pallet_chainbridge::Config for MockRuntime {
     type Event = Event;
-    type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
     type Proposal = Call;
-    type ChainId = TestChainId;
+    type ChainId = ChainId;
+    type PalletId = ChainBridgePalletId;
+    type AdminOrigin = EnsureSignedBy<TestUserId, u64>;
     type ProposalLifetime = ProposalLifetime;
+    type WeightInfo = MockWeightInfo;
 }
 
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
 
-frame_support::construct_runtime!(
-    pub enum Test where
-        Block = Block,
-        NodeBlock = Block,
-        UncheckedExtrinsic = UncheckedExtrinsic
-    {
-        System: system::{Pallet, Call, Event<T>},
-        Balances: balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-        Bridge: bridge::{Pallet, Call, Storage, Event<T>},
-    }
-);
+// ----------------------------------------------------------------------------
+// Test externalities
+// ----------------------------------------------------------------------------
 
-// pub const BRIDGE_ID: u64 =
-pub const RELAYER_A: u64 = 0x2;
-pub const RELAYER_B: u64 = 0x3;
-pub const RELAYER_C: u64 = 0x4;
-pub const ENDOWED_BALANCE: u64 = 100_000_000;
-pub const TEST_THRESHOLD: u32 = 2;
+// Test externalities builder type declaraction.
+//
+// This type is mainly used for mocking storage in tests. It is the type alias 
+// for an in-memory, hashmap-based externalities implementation.
+pub struct TestExternalitiesBuilder {}
 
-pub fn new_test_ext() -> sp_io::TestExternalities {
-    let bridge_id = PalletId(*b"cb/bridg").into_account();
-    let mut t = frame_system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap();
-    pallet_balances::GenesisConfig::<Test> {
-        balances: vec![(bridge_id, ENDOWED_BALANCE)],
-    }
-    .assimilate_storage(&mut t)
-    .unwrap();
-    let mut ext = sp_io::TestExternalities::new(t);
-    ext.execute_with(|| System::set_block_number(1));
-    ext
+// Default trait implementation for test externalities builder
+impl Default for TestExternalitiesBuilder {
+	fn default() -> Self {
+		Self {}
+	}
 }
 
-pub fn new_test_ext_initialized(
-    src_id: ChainId,
-    r_id: ResourceId,
-    resource: Vec<u8>,
-) -> sp_io::TestExternalities {
-    let mut t = new_test_ext();
-    t.execute_with(|| {
-        // Set and check threshold
-        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD));
-        assert_eq!(Bridge::relayer_threshold(), TEST_THRESHOLD);
-        // Add relayers
-        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_A));
-        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_B));
-        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_C));
-        // Whitelist chain
-        assert_ok!(Bridge::whitelist_chain(Origin::root(), src_id));
-        // Set and check resource ID mapped to some junk data
-        assert_ok!(Bridge::set_resource(Origin::root(), r_id, resource));
-        assert_eq!(Bridge::resource_exists(r_id), true);
-    });
-    t
+impl TestExternalitiesBuilder {
+        
+    // Build a genesis storage key/value store
+	pub(crate) fn build(self) -> TestExternalities {
+
+        let bridge_id = ChainBridge::PalletId::get().into_account();
+
+		let mut storage = frame_system::GenesisConfig::default()
+            .build_storage::<MockRuntime>()
+            .unwrap();
+
+        // pre-fill balances
+        pallet_balances::GenesisConfig::<MockRuntime> {
+            balances: vec![
+                (bridge_id, ENDOWED_BALANCE),
+            ],
+        }.assimilate_storage(&mut storage).unwrap();
+
+        let mut externalities = TestExternalities::new(storage);
+        externalities.execute_with(|| System::set_block_number(1));
+        externalities
+    }
+
+    pub fn build_with(
+        self, 
+        src_id: ChainId,
+        r_id: ResourceId,
+        resource: Vec<u8>
+    ) -> TestExternalities {
+        let mut externalities = Self::build(self);
+
+        externalities.execute_with(|| {
+            // Set and check threshold
+            assert_ok!(ChainBridge::set_threshold(Origin::root(), TEST_THRESHOLD));
+            assert_eq!(ChainBridge::get_relayer_threshold(), TEST_THRESHOLD);
+            // Add relayers
+            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_A));
+            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_B));
+            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_C));
+            // Whitelist chain
+            assert_ok!(ChainBridge::whitelist_chain(Origin::root(), src_id));
+            // Set and check resource ID mapped to some junk data
+            assert_ok!(ChainBridge::set_resource(Origin::root(), r_id, resource));
+            assert_eq!(ChainBridge::resource_exists(r_id), true);
+        });
+        externalities
+    }
 }
 
 // Checks events against the latest. A contiguous set of events must be provided. They must
 // include the most recent event, but do not have to include every past event.
 pub fn assert_events(mut expected: Vec<Event>) {
-    let mut actual: Vec<Event> = system::Pallet::<Test>::events()
+    let mut actual: Vec<Event> = frame_system::Pallet::<MockRuntime>::events()
         .iter()
         .map(|e| e.event.clone())
         .collect();

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -21,7 +21,13 @@
 // Module imports and re-exports
 // ----------------------------------------------------------------------------
 
-use frame_support::{PalletId, assert_ok, parameter_types, traits::SortedMembers, weights::Weight};
+use frame_support::{
+    assert_ok, 
+    PalletId, 
+    parameter_types, 
+    traits::SortedMembers, 
+    weights::Weight
+};
 
 use frame_system::EnsureSignedBy;
 
@@ -55,9 +61,6 @@ use crate::{
 type Balance = u64;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<MockRuntime>;
 type Block = frame_system::mocking::MockBlock<MockRuntime>;
-// TODO [ToZ] - Old type aliases
-//pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-//pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
 
 // Implement testing extrinsic weights for the pallet
 pub struct MockWeightInfo;
@@ -189,14 +192,14 @@ impl pallet_balances::Config for MockRuntime {
     type MaxLocks = ();
 }
 
-// Parameterize chain bridge pallet
+// Parameterize chainbridge pallet
 parameter_types! {
     pub const MockChainId: ChainId = 5;
     pub const ChainBridgePalletId: PalletId = PalletId(*b"chnbrdge");
     pub const ProposalLifetime: u64 = 10;
 }
 
-// Implement chain bridge pallet configuration trait for the mock runtime
+// Implement chainbridge pallet configuration trait for the mock runtime
 impl pallet_chainbridge::Config for MockRuntime {
     type Event = Event;
     type Proposal = Call;

--- a/chainbridge/src/traits.rs
+++ b/chainbridge/src/traits.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Traits used by the Substrate/Ethereum chains bridging pallet.
+
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Frame, system and frame primitives
+use frame_support::weights::Weight;
+
+
+// ----------------------------------------------------------------------------
+// Traits declaration
+// ----------------------------------------------------------------------------
+
+/// Weight information for pallet extrinsics
+///
+/// Weights are calculated using runtime benchmarking features.
+/// See [`benchmarking`] module for more information. 
+pub trait WeightInfo {
+
+    fn set_threshold() -> Weight;
+
+    fn set_resource() -> Weight;
+    
+    fn remove_resource() -> Weight;
+
+    fn whitelist_chain() -> Weight;
+
+    fn add_relayer() -> Weight;
+
+    fn remove_relayer() -> Weight;
+
+    fn acknowledge_proposal() -> Weight;
+
+    fn reject_proposal() -> Weight;
+
+    fn eval_vote_state() -> Weight;
+}

--- a/chainbridge/src/traits.rs
+++ b/chainbridge/src/traits.rs
@@ -44,9 +44,9 @@ pub trait WeightInfo {
 
     fn remove_relayer() -> Weight;
 
-    fn acknowledge_proposal() -> Weight;
+    fn acknowledge_proposal(dispatch_weight: Weight) -> Weight;
 
     fn reject_proposal() -> Weight;
 
-    fn eval_vote_state() -> Weight;
+    fn eval_vote_state(dispatch_weight: Weight) -> Weight;
 }

--- a/chainbridge/src/types.rs
+++ b/chainbridge/src/types.rs
@@ -88,8 +88,8 @@ impl<A: PartialEq, B: PartialOrd + Default> ProposalVotes<A, B> {
 impl<AccountId, BlockNumber: Default> Default for ProposalVotes<AccountId, BlockNumber> {
     fn default() -> Self {
         Self {
-            votes_for: Vec::new(),
-            votes_against: Vec::new(),
+            votes_for: vec![],
+            votes_against: vec![],
             status: ProposalStatus::Initiated,
             expiry: BlockNumber::default(),
         }

--- a/chainbridge/src/types.rs
+++ b/chainbridge/src/types.rs
@@ -1,0 +1,97 @@
+
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Types used by the Substrate/Ethereum chains bridging pallet.
+
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Substrate primitives
+use codec::{
+    Decode, 
+    Encode
+};
+
+use sp_runtime::RuntimeDebug;
+
+
+// ----------------------------------------------------------------------------
+// Types definition
+// ----------------------------------------------------------------------------
+
+pub type ChainId = u8;
+pub type DepositNonce = u64;
+pub type ResourceId = [u8; 32];
+
+/// Enumeration of proposal status.
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub enum ProposalStatus {
+    Initiated,
+    Approved,
+    Rejected,
+}
+
+/// Proposal votes data structure.
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub struct ProposalVotes<AccountId, BlockNumber> {
+    pub votes_for: Vec<AccountId>,
+    pub votes_against: Vec<AccountId>,
+    pub status: ProposalStatus,
+    pub expiry: BlockNumber,
+}
+
+impl<A: PartialEq, B: PartialOrd + Default> ProposalVotes<A, B> {
+    /// Attempts to mark the proposal as approve or rejected.
+    /// Returns true if the status changes from active.
+    pub(crate) fn try_to_complete(&mut self, threshold: u32, total: u32) -> ProposalStatus {
+        if self.votes_for.len() >= threshold as usize {
+            self.status = ProposalStatus::Approved;
+            ProposalStatus::Approved
+        } else if total >= threshold && self.votes_against.len() as u32 + threshold > total {
+            self.status = ProposalStatus::Rejected;
+            ProposalStatus::Rejected
+        } else {
+            ProposalStatus::Initiated
+        }
+    }
+
+    /// Returns true if the proposal has been rejected or approved, otherwise false.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.status != ProposalStatus::Initiated
+    }
+
+    /// Returns true if `who` has voted for or against the proposal
+    pub(crate) fn has_voted(&self, who: &A) -> bool {
+        self.votes_for.contains(&who) || self.votes_against.contains(&who)
+    }
+
+    /// Return true if the expiry time has been reached
+    pub(crate) fn is_expired(&self, now: B) -> bool {
+        self.expiry <= now
+    }
+}
+
+// Implement default trait for the proposal votes structure.
+impl<AccountId, BlockNumber: Default> Default for ProposalVotes<AccountId, BlockNumber> {
+    fn default() -> Self {
+        Self {
+            votes_for: Vec::new(),
+            votes_against: Vec::new(),
+            status: ProposalStatus::Initiated,
+            expiry: BlockNumber::default(),
+        }
+    }
+}

--- a/chainbridge/src/types.rs
+++ b/chainbridge/src/types.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2021 Centrifuge Foundation (centrifuge.io).
 // This file is part of Centrifuge chain project.
 

--- a/chainbridge/src/weights.rs
+++ b/chainbridge/src/weights.rs
@@ -1,0 +1,66 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Extrinsincs weight information for Substrate/Ethereum chains bridging pallet.
+//! 
+//! Note that the following weights are used only for development.
+//! In fact, weights shoudl be calculated using runtime benchmarking.
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+use frame_support::weights::Weight;
+
+use crate::traits::WeightInfo;
+
+
+impl WeightInfo for () {
+    fn set_threshold() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn set_resource() -> Weight {
+        195_000_000 as Weight
+    }
+    
+    fn remove_resource() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn whitelist_chain() -> Weight {
+        195_000_000 as Weight    
+    }
+
+    fn add_relayer() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn remove_relayer() -> Weight {
+        195_000_000 as Weight
+    }
+
+    // #[weight = (call.get_dispatch_info().weight + 195_000_000, call.get_dispatch_info().class, Pays::Yes)]
+    fn acknowledge_proposal() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn reject_proposal() -> Weight {
+        195_000_000 as Weight
+    }
+
+    // #[weight = (prop.get_dispatch_info().weight + 195_000_000, prop.get_dispatch_info().class, Pays::Yes)]
+    fn eval_vote_state() -> Weight {
+        195_000_000 as Weight
+    }
+}

--- a/chainbridge/src/weights.rs
+++ b/chainbridge/src/weights.rs
@@ -50,17 +50,15 @@ impl WeightInfo for () {
         195_000_000 as Weight
     }
 
-    // #[weight = (call.get_dispatch_info().weight + 195_000_000, call.get_dispatch_info().class, Pays::Yes)]
-    fn acknowledge_proposal() -> Weight {
-        195_000_000 as Weight
+    fn acknowledge_proposal(dispatch_weight: Weight) -> Weight {
+        (195_000_000 as Weight).saturating_add(dispatch_weight)
     }
 
     fn reject_proposal() -> Weight {
         195_000_000 as Weight
     }
 
-    // #[weight = (prop.get_dispatch_info().weight + 195_000_000, prop.get_dispatch_info().class, Pays::Yes)]
-    fn eval_vote_state() -> Weight {
-        195_000_000 as Weight
+    fn eval_vote_state(dispatch_weight: Weight) -> Weight {
+        (195_000_000 as Weight).saturating_add(dispatch_weight)
     }
 }

--- a/example-erc721/Cargo.toml
+++ b/example-erc721/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = 'example-erc721'
+name = 'pallet-example-erc721'
 version = '0.0.1'
 authors = ['david@chainsafe.io']
 edition = '2018'
@@ -7,25 +7,27 @@ edition = '2018'
 [dependencies]
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.101", optional = true }
+serde = { version = "1.0.102", optional = true }
 
 # primitives
-sp-std = { version = "3.0.0", default-features = false }
-sp-runtime = { version = "3.0.0", default-features = false }
-sp-io = { version = "3.0.0", default-features = false }
-sp-core = { version = "3.0.0", default-features = false }
+sp-io = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+sp-core = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+sp-runtime = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+sp-std = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
 
 # frame dependencies
-frame-support = { version = "3.0.0", default-features = false }
-frame-system = { version = "3.0.0", default-features = false }
+frame-support = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+frame-system = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 
+# local dependencies
 chainbridge = { path = "../chainbridge" , default-features = false }
 
 [dev-dependencies]
-pallet-balances = { version = "3.0.0",default-features = false }
+pallet-balances = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 
 [build-dependencies]
-wasm-builder-runner = { version = "2.0.0", package = "substrate-wasm-builder-runner"}
+wasm-builder-runner = { version = "3.0.0", package = "substrate-wasm-builder-runner"}
+
 [features]
 default = ["std"]
 std = [

--- a/example-erc721/src/lib.rs
+++ b/example-erc721/src/lib.rs
@@ -1,51 +1,217 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! # Example ERC721 pallet
+
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
-use frame_support::{
-    decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
-    traits::Get,
-};
-use frame_system::{self as system, ensure_root, ensure_signed};
-use sp_core::U256;
-use sp_runtime::RuntimeDebug;
-use sp_std::prelude::*;
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
 
+// Mock runtime and unit test cases
+#[cfg(test)]
 mod mock;
+
+#[cfg(test)]
 mod tests;
 
-type TokenId = U256;
+// Pallet types and traits
+pub mod types;
+pub mod traits;
 
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub struct Erc721Token {
-    pub id: TokenId,
-    pub metadata: Vec<u8>,
-}
+// Pallet extrinsics weight information
+mod weights;
 
-pub trait Config: system::Config {
-    type Event: From<Event<Self>> + Into<<Self as system::Config>::Event>;
+// Substrate primitives
+use frame_support::{
+    dispatch::{
+        DispatchResult,
+        DispatchResultWithPostInfo,
+    },
+    ensure,
+    traits::Get,
+};
 
-    /// Some identifier for this token type, possibly the originating ethereum address.
-    /// This is not explicitly used for anything, but may reflect the bridge's notion of resource ID.
-    type Identifier: Get<[u8; 32]>;
-}
+use frame_system::{
+    ensure_root,
+    ensure_signed
+};
 
-decl_event! {
-    pub enum Event<T>
-    where
-        <T as system::Config>::AccountId,
-    {
+use sp_core::U256;
+
+use sp_std::prelude::*;
+
+use crate::{
+    traits::WeightInfo,
+    types::{
+        TokenId,
+        Erc721Token,
+    }
+};
+
+// Re-export pallet components in crate namespace (for runtime construction)
+pub use pallet::*;
+
+
+// ----------------------------------------------------------------------------
+// Pallet module
+// ----------------------------------------------------------------------------
+
+// Chain bridge pallet module
+//
+// The name of the pallet is provided by `construct_runtime` and is used as
+// the unique identifier for the pallet's storage. It is not defined in the 
+// pallet itself.
+#[frame_support::pallet]
+pub mod pallet {
+
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+    // Bridge pallet type declaration.
+    //
+    // This structure is a placeholder for traits and functions implementation
+    // for the pallet.
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
+
+
+    // ------------------------------------------------------------------------
+    // Pallet configuration
+    // ------------------------------------------------------------------------
+
+    /// Example ERC721 pallet's configuration trait.
+    ///
+    /// Associated types and constants are declared in this trait. If the pallet
+    /// depends on other super-traits, the latter must be added to this trait, 
+    /// such as, in this case, [`frame_system::Config`] super-trait, for instance. 
+    /// Note that [`frame_system::Config`] must always be included.
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+
+        /// Associated type for Event enum
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        /// Some identifier for this token type, possibly the originating ethereum address.
+        /// This is not explicitly used for anything, but may reflect the bridge's notion of resource ID.
+        type Identifier: Get<[u8; 32]>;
+    
+        /// Weight information for extrinsics in this pallet
+        type WeightInfo: WeightInfo;
+    }
+
+
+    // ------------------------------------------------------------------------
+    // Pallet events
+    // ------------------------------------------------------------------------
+
+    // The macro generates event metadata and derive Clone, Debug, Eq, PartialEq and Codec
+    #[pallet::event]
+    // The macro generates a function on Pallet to deposit an event
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
         /// New token created
-        Minted(AccountId, TokenId),
+        Minted(<T as frame_system::Config>::AccountId, TokenId),
         /// Token transfer between two parties
-        Transferred(AccountId, AccountId, TokenId),
+        Transferred(<T as frame_system::Config>::AccountId, <T as frame_system::Config>::AccountId, TokenId),
         /// Token removed from the system
         Burned(TokenId),
     }
-}
 
-decl_error! {
-    pub enum Error for Module<T: Config> {
+    // ------------------------------------------------------------------------
+    // Pallet storage items
+    // ------------------------------------------------------------------------
+    
+    /// Maps tokenId to Erc721 object
+    #[pallet::storage]
+    #[pallet::getter(fn get_tokens)]
+    pub(super) type Tokens<T: Config> = StorageMap<
+        _,
+        Blake2_256,
+        TokenId,
+        Erc721Token,
+        OptionQuery
+    >;
+    
+    /// Maps tokenId to owner
+    #[pallet::storage]
+    #[pallet::getter(fn get_owner_of)]
+    pub(super) type TokenOwner<T: Config> = StorageMap<
+        _,
+        Blake2_256,
+        TokenId,
+        T::AccountId,
+        OptionQuery
+    >;
+
+    // Default (or initial) value for [`TokenCount`] storage item
+	#[pallet::type_value]
+	pub fn OnTokenCountEmpty<T: Config>() -> U256 {
+		U256::zero()
+	}
+
+    /// Total number of tokens in existence
+    #[pallet::storage]
+    #[pallet::getter(fn get_token_count)]
+    pub(super) type TokenCount<T: Config> = StorageValue<
+        _,
+        U256,
+        ValueQuery,
+        OnTokenCountEmpty<T>
+    >;
+
+	
+    // ------------------------------------------------------------------------
+	// Pallet genesis configuration
+	// ------------------------------------------------------------------------
+
+	// The genesis configuration type.
+	#[pallet::genesis_config]
+	pub struct GenesisConfig {}
+
+	// The default value for the genesis config type.
+	#[cfg(feature = "std")]
+	impl Default for GenesisConfig {
+		fn default() -> Self {
+			Self {}
+		}
+	}
+
+	// The build of genesis for the pallet.
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {}
+	}
+
+
+    // ------------------------------------------------------------------------
+    // Pallet lifecycle hooks
+    // ------------------------------------------------------------------------
+    
+    #[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+
+    // ------------------------------------------------------------------------
+    // Pallet errors
+    // ------------------------------------------------------------------------
+
+    #[pallet::error]
+    pub enum Error<T> {
         /// ID not recognized
         TokenIdDoesNotExist,
         /// Already exists with an owner
@@ -53,71 +219,92 @@ decl_error! {
         /// Origin is not owner
         NotOwner,
     }
-}
 
-decl_storage! {
-    trait Store for Module<T: Config> as TokenStorage {
-        /// Maps tokenId to Erc721 object
-        Tokens get(fn tokens): map hasher(opaque_blake2_256) TokenId => Option<Erc721Token>;
-        /// Maps tokenId to owner
-        TokenOwner get(fn owner_of): map hasher(opaque_blake2_256) TokenId => Option<T::AccountId>;
-        /// Total number of tokens in existence
-        TokenCount get(fn token_count): U256 = U256::zero();
-    }
-}
 
-decl_module! {
-    pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        type Error = Error<T>;
-        fn deposit_event() = default;
+	// ------------------------------------------------------------------------
+	// Pallet dispatchable functions
+	// ------------------------------------------------------------------------
+
+	// Declare Call struct and implement dispatchable (or callable) functions.
+	//
+	// Dispatchable functions are transactions modifying the state of the chain. They
+	// are also called extrinsics are constitute the pallet's public interface.
+	// Note that each parameter used in functions must implement `Clone`, `Debug`,
+	// `Eq`, `PartialEq` and `Codec` traits.
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 
         /// Creates a new token with the given token ID and metadata, and gives ownership to owner
-        #[weight = 195_000_000]
-        pub fn mint(origin, owner: T::AccountId, id: TokenId, metadata: Vec<u8>) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::mint())]
+        pub fn mint(
+            origin: OriginFor<T>,
+            owner: T::AccountId, 
+            id: TokenId, metadata: Vec<u8>) -> DispatchResultWithPostInfo 
+        {
             ensure_root(origin)?;
 
             Self::mint_token(owner, id, metadata)?;
 
-            Ok(())
+            Ok(().into())
         }
 
         /// Changes ownership of a token sender owns
-        #[weight = 195_000_000]
-        pub fn transfer(origin, to: T::AccountId, id: TokenId) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::transfer())]
+        pub fn transfer(
+            origin: OriginFor<T>,
+            to: T::AccountId, 
+            id: TokenId) -> DispatchResultWithPostInfo 
+        {
             let sender = ensure_signed(origin)?;
 
             Self::transfer_from(sender, to, id)?;
 
-            Ok(())
+            Ok(().into())
         }
 
         /// Remove token from the system
-        #[weight = 195_000_000]
-        pub fn burn(origin, id: TokenId) -> DispatchResult {
+        #[pallet::weight(<T as Config>::WeightInfo::burn())]
+        pub fn burn(
+            origin: OriginFor<T>,
+            id: TokenId) -> DispatchResultWithPostInfo 
+        {
             ensure_root(origin)?;
 
-            let owner = Self::owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
+            let owner = Self::get_owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
 
             Self::burn_token(owner, id)?;
 
-            Ok(())
+            Ok(().into())
         }
     }
-}
+} // end of 'pallet' module
 
-impl<T: Config> Module<T> {
+
+// ----------------------------------------------------------------------------
+// Pallet implementation block
+// ----------------------------------------------------------------------------
+
+// Example ERC721 pallet implementation block.
+//
+// This main implementation block contains two categories of functions, namely:
+// - Public functions: These are functions that are `pub` and generally fall into
+//   inspector functions that do not write to storage and operation functions that do.
+// - Private functions: These are private helpers or utilities that cannot be called
+//   from other pallets.
+impl<T: Config> Pallet<T> {
+
     /// Creates a new token in the system.
     pub fn mint_token(owner: T::AccountId, id: TokenId, metadata: Vec<u8>) -> DispatchResult {
-        ensure!(!Tokens::contains_key(id), Error::<T>::TokenAlreadyExists);
+        ensure!(!<Tokens<T>>::contains_key(id), Error::<T>::TokenAlreadyExists);
 
         let new_token = Erc721Token { id, metadata };
 
-        <Tokens>::insert(&id, new_token);
+        <Tokens<T>>::insert(&id, new_token);
         <TokenOwner<T>>::insert(&id, owner.clone());
-        let new_total = <TokenCount>::get().saturating_add(U256::one());
-        <TokenCount>::put(new_total);
+        let new_total = Self::get_token_count().saturating_add(U256::one());
+        <TokenCount<T>>::put(new_total);
 
-        Self::deposit_event(RawEvent::Minted(owner, id));
+        Self::deposit_event(Event::Minted(owner, id));
 
         Ok(())
     }
@@ -125,27 +312,27 @@ impl<T: Config> Module<T> {
     /// Modifies ownership of a token
     pub fn transfer_from(from: T::AccountId, to: T::AccountId, id: TokenId) -> DispatchResult {
         // Check from is owner and token exists
-        let owner = Self::owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
+        let owner = Self::get_owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
         ensure!(owner == from, Error::<T>::NotOwner);
         // Update owner
         <TokenOwner<T>>::insert(&id, to.clone());
 
-        Self::deposit_event(RawEvent::Transferred(from, to, id));
+        Self::deposit_event(Event::Transferred(from, to, id));
 
         Ok(())
     }
 
     /// Deletes a token from the system.
     pub fn burn_token(from: T::AccountId, id: TokenId) -> DispatchResult {
-        let owner = Self::owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
+        let owner = Self::get_owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
         ensure!(owner == from, Error::<T>::NotOwner);
 
-        <Tokens>::remove(&id);
+        <Tokens<T>>::remove(&id);
         <TokenOwner<T>>::remove(&id);
-        let new_total = <TokenCount>::get().saturating_sub(U256::one());
-        <TokenCount>::put(new_total);
+        let new_total = Self::get_token_count().saturating_sub(U256::one());
+        <TokenCount<T>>::put(new_total);
 
-        Self::deposit_event(RawEvent::Burned(id));
+        Self::deposit_event(Event::Burned(id));
 
         Ok(())
     }

--- a/example-erc721/src/mock.rs
+++ b/example-erc721/src/mock.rs
@@ -1,19 +1,103 @@
-#![cfg(test)]
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
 
-use frame_support::{ord_parameter_types, parameter_types, weights::Weight};
-use frame_system::{self as system};
-use sp_core::hashing::blake2_128;
-use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    BuildStorage, Perbill,
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Mocking runtime for testing the Substrate/Ethereum example ERC721 pallet.
+//!
+//! The main components implemented in this mock module is a mock runtime
+//! and some helper functions.
+
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+use frame_support::{
+    parameter_types, 
+    weights::Weight
 };
 
-use crate::{self as erc721, Config};
-use chainbridge as bridge;
-pub use pallet_balances as balances;
+use sp_core::{
+    blake2_128,
+    H256, 
+};
 
+use sp_io::TestExternalities;
+
+use sp_runtime::{
+    testing::Header,
+    traits::{
+        BlakeTwo256, 
+        IdentityLookup
+    },
+    Perbill,
+};
+
+use crate::{
+    self as pallet_example_erc721,
+    traits::WeightInfo, 
+};
+
+
+// ----------------------------------------------------------------------------
+// Types and constants declaration
+// ----------------------------------------------------------------------------
+
+type Balance = u64;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<MockRuntime>;
+type Block = frame_system::mocking::MockBlock<MockRuntime>;
+
+// Implement testing extrinsic weights for the pallet
+pub struct MockWeightInfo;
+impl WeightInfo for MockWeightInfo {
+
+    fn mint() -> Weight {
+        0 as Weight
+    }
+
+    fn transfer() -> Weight {
+        0 as Weight
+    }
+
+    fn burn() -> Weight {
+        0 as Weight
+    }
+}
+
+pub const USER_A: u64 = 0x1;
+pub const USER_B: u64 = 0x2;
+pub const USER_C: u64 = 0x3;
+pub const ENDOWED_BALANCE: u64 = 100_000_000;
+
+
+// ----------------------------------------------------------------------------
+// Mock runtime configuration
+// ----------------------------------------------------------------------------
+
+// Build mock runtime
+frame_support::construct_runtime!(
+
+    pub enum MockRuntime where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Erc721: pallet_example_erc721::{Pallet, Call, Storage, Event<T>},
+    }
+);
+
+// Parameterize FRAME system pallet
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const MaximumBlockWeight: Weight = 1024;
@@ -22,7 +106,8 @@ parameter_types! {
     pub const MaxLocks: u32 = 100;
 }
 
-impl frame_system::Config for Test {
+// Implement FRAME system pallet configuration trait for the mock runtime
+impl frame_system::Config for MockRuntime {
     type BaseCallFilter = ();
     type Origin = Origin;
     type Call = Call;
@@ -45,62 +130,71 @@ impl frame_system::Config for Test {
     type BlockWeights = ();
     type BlockLength = ();
     type SS58Prefix = ();
+    type OnSetCode = ();
 }
 
+// Parameterize FRAME balances pallet
 parameter_types! {
     pub const ExistentialDeposit: u64 = 1;
 }
 
-ord_parameter_types! {
-    pub const One: u64 = 1;
-}
-
-impl pallet_balances::Config for Test {
-    type Balance = u64;
+// Implement FRAME balances pallet configuration trait for the mock runtime
+impl pallet_balances::Config for MockRuntime {
+    type Balance = Balance;
     type DustRemoval = ();
     type Event = Event;
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
-    type MaxLocks = MaxLocks;
     type WeightInfo = ();
+    type MaxLocks = ();
 }
 
+// Parameterize ERC721 pallet
 parameter_types! {
-    pub Erc721Id: bridge::ResourceId = bridge::derive_resource_id(1, &blake2_128(b"NFT"));
+    pub Erc721Id: chainbridge::types::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"NFT"));
 }
 
-impl Config for Test {
+// Implement FRAME ERC721 pallet configuration trait for the mock runtime
+impl pallet_example_erc721::Config for MockRuntime {
     type Event = Event;
     type Identifier = Erc721Id;
+    type WeightInfo = MockWeightInfo;
 }
 
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
 
-frame_support::construct_runtime!(
-    pub enum Test where
-        Block = Block,
-        NodeBlock = Block,
-        UncheckedExtrinsic = UncheckedExtrinsic
-    {
-        System: system::{Module, Call, Event<T>},
-        Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
-        Erc721: erc721::{Module, Call, Storage, Event<T>},
+// ----------------------------------------------------------------------------
+// Test externalities
+// ----------------------------------------------------------------------------
+
+// Test externalities builder type declaraction.
+//
+// This type is mainly used for mocking storage in tests. It is the type alias 
+// for an in-memory, hashmap-based externalities implementation.
+pub struct TestExternalitiesBuilder {}
+
+// Default trait implementation for test externalities builder
+impl Default for TestExternalitiesBuilder {
+	fn default() -> Self {
+		Self {}
+	}
+}
+
+impl TestExternalitiesBuilder {
+        
+    // Build a genesis storage key/value store
+	pub(crate) fn build(self) -> TestExternalities {
+
+		let mut storage = frame_system::GenesisConfig::default()
+            .build_storage::<MockRuntime>()
+            .unwrap();
+
+        // pre-fill balances
+        pallet_balances::GenesisConfig::<MockRuntime> {
+            balances: vec![
+                (USER_A, ENDOWED_BALANCE),
+            ],
+        }.assimilate_storage(&mut storage).unwrap();
+
+        TestExternalities::new(storage)
     }
-);
-
-pub const USER_A: u64 = 0x1;
-pub const USER_B: u64 = 0x2;
-pub const USER_C: u64 = 0x3;
-pub const ENDOWED_BALANCE: u64 = 100_000_000;
-
-pub fn new_test_ext() -> sp_io::TestExternalities {
-    GenesisConfig {
-        balances: Some(balances::GenesisConfig {
-            balances: vec![(USER_A, ENDOWED_BALANCE)],
-        }),
-    }
-    .build_storage()
-    .unwrap()
-    .into()
 }

--- a/example-erc721/src/tests.rs
+++ b/example-erc721/src/tests.rs
@@ -1,13 +1,42 @@
-#![cfg(test)]
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
 
-use super::mock::{new_test_ext, Erc721, Origin, Test, USER_A, USER_B, USER_C};
-use super::*;
-use frame_support::{assert_noop, assert_ok};
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! # Example ERC721 pallet's unit test cases.
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+use crate::{
+    mock::*,
+    *,
+};
+
+use frame_support::{
+    assert_noop, 
+    assert_ok
+};
+
 use sp_core::U256;
+
+
+// ----------------------------------------------------------------------------
+// Test cases
+// ----------------------------------------------------------------------------
 
 #[test]
 fn mint_burn_tokens() {
-    new_test_ext().execute_with(|| {
+    TestExternalitiesBuilder::default().build().execute_with(|| {
         let id_a: U256 = 1.into();
         let id_b: U256 = 2.into();
         let metadata_a: Vec<u8> = vec![1, 2, 3];
@@ -20,16 +49,16 @@ fn mint_burn_tokens() {
             metadata_a.clone()
         ));
         assert_eq!(
-            Erc721::tokens(id_a).unwrap(),
+            Erc721::get_tokens(id_a).unwrap(),
             Erc721Token {
                 id: id_a,
                 metadata: metadata_a.clone()
             }
         );
-        assert_eq!(Erc721::token_count(), 1.into());
+        assert_eq!(Erc721::get_token_count(), 1.into());
         assert_noop!(
             Erc721::mint(Origin::root(), USER_A, id_a, metadata_a.clone()),
-            Error::<Test>::TokenAlreadyExists
+            Error::<MockRuntime>::TokenAlreadyExists
         );
 
         assert_ok!(Erc721::mint(
@@ -39,33 +68,33 @@ fn mint_burn_tokens() {
             metadata_b.clone()
         ));
         assert_eq!(
-            Erc721::tokens(id_b).unwrap(),
+            Erc721::get_tokens(id_b).unwrap(),
             Erc721Token {
                 id: id_b,
                 metadata: metadata_b.clone()
             }
         );
-        assert_eq!(Erc721::token_count(), 2.into());
+        assert_eq!(Erc721::get_token_count(), 2.into());
         assert_noop!(
             Erc721::mint(Origin::root(), USER_A, id_b, metadata_b.clone()),
-            Error::<Test>::TokenAlreadyExists
+            Error::<MockRuntime>::TokenAlreadyExists
         );
 
         assert_ok!(Erc721::burn(Origin::root(), id_a));
-        assert_eq!(Erc721::token_count(), 1.into());
-        assert!(!<Tokens>::contains_key(&id_a));
-        assert!(!<TokenOwner<Test>>::contains_key(&id_a));
+        assert_eq!(Erc721::get_token_count(), 1.into());
+        assert!(!<Tokens<MockRuntime>>::contains_key(&id_a));
+        assert!(!<TokenOwner<MockRuntime>>::contains_key(&id_a));
 
         assert_ok!(Erc721::burn(Origin::root(), id_b));
-        assert_eq!(Erc721::token_count(), 0.into());
-        assert!(!<Tokens>::contains_key(&id_b));
-        assert!(!<TokenOwner<Test>>::contains_key(&id_b));
+        assert_eq!(Erc721::get_token_count(), 0.into());
+        assert!(!<Tokens<MockRuntime>>::contains_key(&id_b));
+        assert!(!<TokenOwner<MockRuntime>>::contains_key(&id_b));
     })
 }
 
 #[test]
 fn transfer_tokens() {
-    new_test_ext().execute_with(|| {
+    TestExternalitiesBuilder::default().build().execute_with(|| {
         let id_a: U256 = 1.into();
         let id_b: U256 = 2.into();
         let metadata_a: Vec<u8> = vec![1, 2, 3];
@@ -85,15 +114,15 @@ fn transfer_tokens() {
         ));
 
         assert_ok!(Erc721::transfer(Origin::signed(USER_A), USER_B, id_a));
-        assert_eq!(Erc721::owner_of(id_a).unwrap(), USER_B);
+        assert_eq!(Erc721::get_owner_of(id_a).unwrap(), USER_B);
 
         assert_ok!(Erc721::transfer(Origin::signed(USER_A), USER_C, id_b));
-        assert_eq!(Erc721::owner_of(id_b).unwrap(), USER_C);
+        assert_eq!(Erc721::get_owner_of(id_b).unwrap(), USER_C);
 
         assert_ok!(Erc721::transfer(Origin::signed(USER_B), USER_A, id_a));
-        assert_eq!(Erc721::owner_of(id_a).unwrap(), USER_A);
+        assert_eq!(Erc721::get_owner_of(id_a).unwrap(), USER_A);
 
         assert_ok!(Erc721::transfer(Origin::signed(USER_C), USER_A, id_b));
-        assert_eq!(Erc721::owner_of(id_b).unwrap(), USER_A);
+        assert_eq!(Erc721::get_owner_of(id_b).unwrap(), USER_A);
     })
 }

--- a/example-erc721/src/traits.rs
+++ b/example-erc721/src/traits.rs
@@ -1,0 +1,40 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Traits used by the example ERC721 pallet.
+
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Frame, system and frame primitives
+use frame_support::weights::Weight;
+
+
+// ----------------------------------------------------------------------------
+// Traits declaration
+// ----------------------------------------------------------------------------
+
+/// Weight information for example ERC721 pallet extrinsics
+///
+/// Weights are calculated using runtime benchmarking features.
+/// See [`benchmarking`] module for more information. 
+pub trait WeightInfo {
+
+    fn mint() -> Weight;
+
+    fn transfer() -> Weight;
+    
+    fn burn() -> Weight;
+}

--- a/example-erc721/src/types.rs
+++ b/example-erc721/src/types.rs
@@ -1,0 +1,43 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! # Types used by the example ERC721 pallet
+
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Substrate primitives
+use codec::{
+    Decode, 
+    Encode
+};
+
+use sp_runtime::RuntimeDebug;
+
+use sp_core::U256;
+
+
+// ----------------------------------------------------------------------------
+// Types definition
+// ----------------------------------------------------------------------------
+
+
+pub type TokenId = U256;
+
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub struct Erc721Token {
+    pub id: TokenId,
+    pub metadata: Vec<u8>,
+}

--- a/example-erc721/src/weights.rs
+++ b/example-erc721/src/weights.rs
@@ -1,0 +1,41 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Extrinsincs weight information for example ERC721 pallet.
+//! 
+//! Note that the following weights are used only for development.
+//! In fact, weights shoudl be calculated using runtime benchmarking.
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+use frame_support::weights::Weight;
+
+use crate::traits::WeightInfo;
+
+
+impl WeightInfo for () {
+
+    fn mint() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn transfer() -> Weight {
+        195_000_000 as Weight
+    }
+    
+    fn burn() -> Weight {
+        195_000_000 as Weight
+    }
+}

--- a/example-pallet/Cargo.toml
+++ b/example-pallet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = 'example-pallet'
+name = 'pallet-example'
 version = '0.0.1'
 authors = ['david@chainsafe.io']
 edition = '2018'
@@ -10,24 +10,26 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 serde = { version = "1.0.101", optional = true }
 
 # primitives
-sp-std = { version = "3.0.0", default-features = false }
-sp-runtime = { version = "3.0.0", default-features = false }
-sp-io = { version = "3.0.0", default-features = false }
-sp-core = { version = "3.0.0", default-features = false }
-sp-arithmetic = { version = "3.0.0", default-features = false }
+sp-io = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+sp-core = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+sp-runtime = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+sp-std = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+sp-arithmetic = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
 
 # frame dependencies
-frame-support = { version = "3.0.0", default-features = false }
-frame-system = { version = "3.0.0", default-features = false }
+frame-support = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
+frame-system = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 
+# local dependencies
 chainbridge = { path = "../chainbridge" , default-features = false}
-example-erc721 = { path = "../example-erc721", default-features = false }
+pallet-example-erc721 = { path = "../example-erc721", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { version = "3.0.0", default-features = false }
+pallet-balances = { git = "https://github.com/centrifuge/substrate.git", default-features = false, branch = "master" }
 
 [build-dependencies]
-wasm-builder-runner = { version = "2.0.0", package = "substrate-wasm-builder-runner" }
+wasm-builder-runner = { version = "3.0.0", package = "substrate-wasm-builder-runner"}
+
 [features]
 default = ["std"]
 std = [
@@ -41,5 +43,5 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"chainbridge/std",
-    "example-erc721/std"
+    "pallet-example-erc721/std"
 ]

--- a/example-pallet/src/lib.rs
+++ b/example-pallet/src/lib.rs
@@ -1,97 +1,254 @@
-// Ensure we're `no_std` when compiling for Wasm.
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! # Example pallet
+
+// Ensure we're `no_std` when compiling for WebAssembly.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use chainbridge as bridge;
-use example_erc721 as erc721;
-use frame_support::traits::{Currency, EnsureOrigin, ExistenceRequirement::AllowDeath, Get};
-use frame_support::{decl_error, decl_event, decl_module, dispatch::DispatchResult, ensure};
-use frame_system::{self as system, ensure_signed};
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Mock runtime and unit test cases
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+// Pallet types and traits
+mod traits;
+
+// Pallet extrinsics weight information
+mod weights;
+
+use pallet_example_erc721 as erc721;
+
+use frame_support::{
+    dispatch::DispatchResultWithPostInfo,
+    ensure,
+    traits::{
+        Currency, 
+        EnsureOrigin, 
+        ExistenceRequirement::AllowDeath, 
+        Get,
+    }
+};
+
+use frame_system::{
+    ensure_signed
+};
+
 use sp_arithmetic::traits::SaturatedConversion;
 use sp_core::U256;
 use sp_std::prelude::*;
 
-mod mock;
-mod tests;
+use chainbridge::types::{
+    ResourceId, 
+    ChainId
+};
 
-type ResourceId = bridge::ResourceId;
+type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-type BalanceOf<T> =
-    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+use crate::traits::WeightInfo;
 
-pub trait Config: system::Config + bridge::Config + erc721::Config {
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-    /// Specifies the origin check provided by the bridge for calls that can only be called by the bridge pallet
-    type BridgeOrigin: EnsureOrigin<Self::Origin, Success = Self::AccountId>;
+// Re-export pallet components in crate namespace (for runtime construction)
+pub use pallet::*;
 
-    /// The currency mechanism.
-    type Currency: Currency<Self::AccountId>;
 
-    /// Ids can be defined by the runtime and passed in, perhaps from blake2b_128 hashes.
-    type HashId: Get<ResourceId>;
-    type NativeTokenId: Get<ResourceId>;
-    type Erc721Id: Get<ResourceId>;
-}
+// ----------------------------------------------------------------------------
+// Pallet module
+// ----------------------------------------------------------------------------
 
-decl_event! {
-    pub enum Event<T> where
-        <T as frame_system::Config>::Hash,
-    {
-        Remark(Hash),
+// Example pallet module
+//
+// The name of the pallet is provided by `construct_runtime` and is used as
+// the unique identifier for the pallet's storage. It is not defined in the 
+// pallet itself.
+#[frame_support::pallet]
+pub mod pallet {
+
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+    // Example pallet type declaration.
+    //
+    // This structure is a placeholder for traits and functions implementation
+    // for the pallet.
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
+
+    // ------------------------------------------------------------------------
+    // Pallet configuration
+    // ------------------------------------------------------------------------
+
+    /// Example pallet's configuration trait.
+    ///
+    /// Associated types and constants are declared in this trait. If the pallet
+    /// depends on other super-traits, the latter must be added to this trait, 
+    /// such as, in this case, [`chainbridge::Config`] super-trait, for instance. 
+    /// Note that [`frame_system::Config`] must always be included.
+    #[pallet::config]
+    pub trait Config: frame_system::Config + chainbridge::Config + erc721::Config {
+
+        /// Associated type for Event enum
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        /// Specifies the origin check provided by the bridge for calls that can only be called by the bridge pallet
+        type BridgeOrigin: EnsureOrigin<<Self as frame_system::Config>::Origin, Success = <Self as frame_system::Config>::AccountId>;
+
+        /// The currency mechanism.
+        type Currency: Currency<<Self as frame_system::Config>::AccountId>;
+
+        /// Ids can be defined by the runtime and passed in, perhaps from blake2b_128 hashes.
+        type HashId: Get<ResourceId>;
+
+        type NativeTokenId: Get<ResourceId>;
+        
+        type Erc721Id: Get<ResourceId>;
+
+        /// Weight information for extrinsics in this pallet
+        type WeightInfo: WeightInfo;
     }
-}
 
-decl_error! {
-    pub enum Error for Module<T: Config>{
+
+    // ------------------------------------------------------------------------
+    // Pallet events
+    // ------------------------------------------------------------------------
+
+    // The macro generates event metadata and derive Clone, Debug, Eq, PartialEq and Codec
+    #[pallet::event]
+    // The macro generates a function on Pallet to deposit an event
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        Remark(<T as frame_system::Config>::Hash),
+    }
+
+
+	// ------------------------------------------------------------------------
+	// Pallet genesis configuration
+	// ------------------------------------------------------------------------
+
+	// The genesis configuration type.
+	#[pallet::genesis_config]
+	pub struct GenesisConfig {}
+
+	// The default value for the genesis config type.
+	#[cfg(feature = "std")]
+	impl Default for GenesisConfig {
+		fn default() -> Self {
+			Self {}
+		}
+	}
+
+	// The build of genesis for the pallet.
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {}
+	}
+
+    
+    // ------------------------------------------------------------------------
+    // Pallet lifecycle hooks
+    // ------------------------------------------------------------------------
+    
+    #[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+
+    // ------------------------------------------------------------------------
+    // Pallet errors
+    // ------------------------------------------------------------------------
+
+    #[pallet::error]
+    pub enum Error<T> {
         InvalidTransfer,
     }
-}
 
-decl_module! {
-    pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        const HashId: ResourceId = T::HashId::get();
-        const NativeTokenId: ResourceId = T::NativeTokenId::get();
-        const Erc721Id: ResourceId = T::Erc721Id::get();
 
-        fn deposit_event() = default;
+	// ------------------------------------------------------------------------
+	// Pallet dispatchable functions
+	// ------------------------------------------------------------------------
+
+	// Declare Call struct and implement dispatchable (or callable) functions.
+	//
+	// Dispatchable functions are transactions modifying the state of the chain. They
+	// are also called extrinsics are constitute the pallet's public interface.
+	// Note that each parameter used in functions must implement `Clone`, `Debug`,
+	// `Eq`, `PartialEq` and `Codec` traits.
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 
         //
         // Initiation calls. These start a bridge transfer.
         //
 
         /// Transfers an arbitrary hash to a (whitelisted) destination chain.
-        #[weight = 195_000_000]
-        pub fn transfer_hash(origin, hash: T::Hash, dest_id: bridge::ChainId) -> DispatchResult {
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::transfer_hash())]
+        pub fn transfer_hash(
+            origin: OriginFor<T>,
+            hash: <T as frame_system::Config>::Hash, 
+            dest_id: ChainId
+        ) -> DispatchResultWithPostInfo {
             ensure_signed(origin)?;
 
             let resource_id = T::HashId::get();
             let metadata: Vec<u8> = hash.as_ref().to_vec();
-            <bridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)
+            <chainbridge::Pallet<T>>::transfer_generic(dest_id, resource_id, metadata)?;
+            Ok(().into())
         }
 
         /// Transfers some amount of the native token to some recipient on a (whitelisted) destination chain.
-        #[weight = 195_000_000]
-        pub fn transfer_native(origin, amount: BalanceOf<T>, recipient: Vec<u8>, dest_id: bridge::ChainId) -> DispatchResult {
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::transfer_native())]
+        pub fn transfer_native(
+            origin: OriginFor<T>,
+            amount: BalanceOf<T>, 
+            recipient: Vec<u8>, 
+            dest_id: ChainId) -> DispatchResultWithPostInfo
+        {
             let source = ensure_signed(origin)?;
-            ensure!(<bridge::Module<T>>::chain_whitelisted(dest_id), Error::<T>::InvalidTransfer);
-            let bridge_id = <bridge::Module<T>>::account_id();
+            ensure!(<chainbridge::Pallet<T>>::chain_whitelisted(dest_id), Error::<T>::InvalidTransfer);
+            let bridge_id = <chainbridge::Pallet<T>>::account_id();
             T::Currency::transfer(&source, &bridge_id, amount.into(), AllowDeath)?;
 
             let resource_id = T::NativeTokenId::get();
-            <bridge::Module<T>>::transfer_fungible(dest_id, resource_id, recipient, U256::from(amount.saturated_into::<u128>()))
+            <chainbridge::Pallet<T>>::transfer_fungible(dest_id, resource_id, recipient, U256::from(amount.saturated_into::<u128>()))?;
+            
+            Ok(().into())
         }
 
         /// Transfer a non-fungible token (erc721) to a (whitelisted) destination chain.
-        #[weight = 195_000_000]
-        pub fn transfer_erc721(origin, recipient: Vec<u8>, token_id: U256, dest_id: bridge::ChainId) -> DispatchResult {
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::transfer_erc721())]
+        pub fn transfer_erc721(
+            origin: OriginFor<T>,
+            recipient: Vec<u8>,
+            token_id: U256,
+            dest_id: ChainId) -> DispatchResultWithPostInfo
+        {
             let source = ensure_signed(origin)?;
-            ensure!(<bridge::Module<T>>::chain_whitelisted(dest_id), Error::<T>::InvalidTransfer);
-            match <erc721::Module<T>>::tokens(&token_id) {
+            ensure!(<chainbridge::Pallet<T>>::chain_whitelisted(dest_id), Error::<T>::InvalidTransfer);
+            match <erc721::Pallet<T>>::get_tokens(&token_id) {
                 Some(token) => {
-                    <erc721::Module<T>>::burn_token(source, token_id)?;
+                    <erc721::Pallet<T>>::burn_token(source, token_id)?;
                     let resource_id = T::Erc721Id::get();
                     let tid: &mut [u8] = &mut[0; 32];
                     token_id.to_big_endian(tid);
-                    <bridge::Module<T>>::transfer_nonfungible(dest_id, resource_id, tid.to_vec(), recipient, token.metadata)
+                    <chainbridge::Pallet<T>>::transfer_nonfungible(dest_id, resource_id, tid.to_vec(), recipient, token.metadata)?;
+                    Ok(().into())
                 }
                 None => Err(Error::<T>::InvalidTransfer)?
             }
@@ -102,27 +259,42 @@ decl_module! {
         //
 
         /// Executes a simple currency transfer using the bridge account as the source
-        #[weight = 195_000_000]
-        pub fn transfer(origin, to: T::AccountId, amount: BalanceOf<T>, r_id: ResourceId) -> DispatchResult {
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::transfer())]
+        pub fn transfer(
+            origin: OriginFor<T>,
+            to: <T as frame_system::Config>::AccountId,
+            amount: BalanceOf<T>,
+            _r_id: ResourceId) -> DispatchResultWithPostInfo
+        {
             let source = T::BridgeOrigin::ensure_origin(origin)?;
             <T as Config>::Currency::transfer(&source, &to, amount.into(), AllowDeath)?;
-            Ok(())
+            Ok(().into())
         }
 
         /// This can be called by the bridge to demonstrate an arbitrary call from a proposal.
-        #[weight = 195_000_000]
-        pub fn remark(origin, hash: T::Hash, r_id: ResourceId) -> DispatchResult {
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::remark())]
+        pub fn remark(
+            origin: OriginFor<T>,
+            hash: <T as frame_system::Config>::Hash,
+            _r_id: ResourceId) -> DispatchResultWithPostInfo
+        {
             T::BridgeOrigin::ensure_origin(origin)?;
-            Self::deposit_event(RawEvent::Remark(hash));
-            Ok(())
+            Self::deposit_event(Event::Remark(hash));
+            Ok(().into())
         }
 
         /// Allows the bridge to issue new erc721 tokens
-        #[weight = 195_000_000]
-        pub fn mint_erc721(origin, recipient: T::AccountId, id: U256, metadata: Vec<u8>, r_id: ResourceId) -> DispatchResult {
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::mint_erc721())]
+        pub fn mint_erc721(
+            origin: OriginFor<T>,
+            recipient: <T as frame_system::Config>::AccountId,
+            id: U256,
+            metadata: Vec<u8>,
+            _r_id: ResourceId) -> DispatchResultWithPostInfo
+        {
             T::BridgeOrigin::ensure_origin(origin)?;
-            <erc721::Module<T>>::mint_token(recipient, id, metadata)?;
-            Ok(())
+            <erc721::Pallet<T>>::mint_token(recipient, id, metadata)?;
+            Ok(().into())
         }
     }
-}
+} // end of 'pallet' module

--- a/example-pallet/src/traits.rs
+++ b/example-pallet/src/traits.rs
@@ -1,0 +1,47 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Traits used by the example pallet.
+
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Frame, system and frame primitives
+use frame_support::weights::Weight;
+
+
+// ----------------------------------------------------------------------------
+// Traits declaration
+// ----------------------------------------------------------------------------
+
+/// Weight information for pallet extrinsics
+///
+/// Weights are calculated using runtime benchmarking features.
+/// See [`benchmarking`] module for more information. 
+pub trait WeightInfo {
+
+
+    fn transfer_hash() -> Weight;
+
+    fn transfer_native() -> Weight;
+    
+    fn transfer_erc721() -> Weight;
+
+    fn transfer() -> Weight;
+
+    fn remark() -> Weight;
+
+    fn mint_erc721() -> Weight;
+}

--- a/example-pallet/src/weights.rs
+++ b/example-pallet/src/weights.rs
@@ -1,0 +1,53 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Extrinsincs weight information for example pallet.
+//! 
+//! Note that the following weights are used only for development.
+//! In fact, weights shoudl be calculated using runtime benchmarking.
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+use frame_support::weights::Weight;
+
+use crate::traits::WeightInfo;
+
+
+impl WeightInfo for () {
+
+    fn transfer_hash() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn transfer_native() -> Weight {
+        195_000_000 as Weight
+    }
+    
+    fn transfer_erc721() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn transfer() -> Weight {
+        195_000_000 as Weight    
+    }
+
+    fn remark() -> Weight {
+        195_000_000 as Weight
+    }
+
+    fn mint_erc721() -> Weight {
+        195_000_000 as Weight
+    }
+}


### PR DESCRIPTION
This PR aims at migrating the `chainbridge` pallet to the new Substrate FRAME v2's [pallet macros](https://crates.parity.io/frame_support/attr.pallet.html).

The Github Actions workflow was modified as well, to support a more recent Rust nightly toolchain.