### PR TITLE
Remove genesis from chainbridge and examples

### DIFF
--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -272,28 +272,6 @@ pub mod pallet {
         StorageMap<_, Blake2_256, ResourceId, Vec<u8>, OptionQuery>;
 
     // // ------------------------------------------------------------------------
-    // // Pallet genesis configuration
-    // // ------------------------------------------------------------------------
-
-    // // The genesis configuration type.
-    // #[pallet::genesis_config]
-    // pub struct GenesisConfig {}
-
-    // // The default value for the genesis config type.
-    // #[cfg(feature = "std")]
-    // impl Default for GenesisConfig {
-    //     fn default() -> Self {
-    //         Self {}
-    //     }
-    // }
-
-    // // The build of genesis for the pallet.
-    // #[pallet::genesis_build]
-    // impl<T: Config> GenesisBuild<T> for GenesisConfig {
-    //     fn build(&self) {}
-    // }
-
-    // // ------------------------------------------------------------------------
     // // Pallet lifecycle hooks
     // // ------------------------------------------------------------------------
 

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -271,31 +271,31 @@ pub mod pallet {
     pub(super) type Resources<T: Config> =
         StorageMap<_, Blake2_256, ResourceId, Vec<u8>, OptionQuery>;
 
-    // ------------------------------------------------------------------------
-    // Pallet genesis configuration
-    // ------------------------------------------------------------------------
+    // // ------------------------------------------------------------------------
+    // // Pallet genesis configuration
+    // // ------------------------------------------------------------------------
 
-    // The genesis configuration type.
-    #[pallet::genesis_config]
-    pub struct GenesisConfig {}
+    // // The genesis configuration type.
+    // #[pallet::genesis_config]
+    // pub struct GenesisConfig {}
 
-    // The default value for the genesis config type.
-    #[cfg(feature = "std")]
-    impl Default for GenesisConfig {
-        fn default() -> Self {
-            Self {}
-        }
-    }
+    // // The default value for the genesis config type.
+    // #[cfg(feature = "std")]
+    // impl Default for GenesisConfig {
+    //     fn default() -> Self {
+    //         Self {}
+    //     }
+    // }
 
-    // The build of genesis for the pallet.
-    #[pallet::genesis_build]
-    impl<T: Config> GenesisBuild<T> for GenesisConfig {
-        fn build(&self) {}
-    }
+    // // The build of genesis for the pallet.
+    // #[pallet::genesis_build]
+    // impl<T: Config> GenesisBuild<T> for GenesisConfig {
+    //     fn build(&self) {}
+    // }
 
-    // ------------------------------------------------------------------------
-    // Pallet lifecycle hooks
-    // ------------------------------------------------------------------------
+    // // ------------------------------------------------------------------------
+    // // Pallet lifecycle hooks
+    // // ------------------------------------------------------------------------
 
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -271,13 +271,6 @@ pub mod pallet {
     pub(super) type Resources<T: Config> =
         StorageMap<_, Blake2_256, ResourceId, Vec<u8>, OptionQuery>;
 
-    // // ------------------------------------------------------------------------
-    // // Pallet lifecycle hooks
-    // // ------------------------------------------------------------------------
-
-    #[pallet::hooks]
-    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
-
     // ------------------------------------------------------------------------
     // Pallet errors
     // ------------------------------------------------------------------------

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -74,17 +74,16 @@
 // Module imports and re-exports
 // ----------------------------------------------------------------------------
 
+// Pallet modules
+pub mod constants;
+mod traits;
+pub mod types;
 // Mock runtime and unit test cases
 #[cfg(test)]
 mod mock;
 
 #[cfg(test)]
 mod tests;
-
-// Pallet modules
-pub mod constants;
-mod traits;
-pub mod types;
 
 // Pallet extrinsics weight information
 mod weights;
@@ -269,7 +268,21 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn get_resources)]
     pub(super) type Resources<T: Config> =
-        StorageMap<_, Blake2_256, ResourceId, Vec<u8>, OptionQuery>;
+    StorageMap<_, Blake2_256, ResourceId, Vec<u8>, OptionQuery>;
+
+    // ------------------------------------------------------------------------
+    // Pallet hooks
+    // ------------------------------------------------------------------------
+
+    // FIXME (ToZ):
+    // This pallet does not compile without this optional hooks section. Weird
+    // as this section is optional (i.e. the same as the one below is automatically
+    // generated if none is given (according to the FRAME documentation). Must 
+    // investigate further.
+    //
+    // See https://crates.parity.io/frame_support/attr.pallet.html#hooks-pallethooks-optional)
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
     // ------------------------------------------------------------------------
     // Pallet errors

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -110,7 +110,7 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Config<T>, Storage, Event<T>},
-        ChainBridge: pallet_chainbridge::{Pallet, Call, Storage, Config, Event<T>},
+        ChainBridge: pallet_chainbridge::{Pallet, Call, Storage, Event<T>},
     }
 );
 
@@ -180,7 +180,7 @@ impl pallet_balances::Config for MockRuntime {
 // Parameterize chainbridge pallet
 parameter_types! {
     pub const MockChainId: ChainId = 5;
-    pub const ChainBridgePalletId: PalletId = PalletId(*b"cb/brdge");
+    pub const ChainBridgePalletId: PalletId = PalletId(*b"chnbridg");
     pub const ProposalLifetime: u64 = 10;
     pub const RelayerVoteThreshold: u32 = DEFAULT_RELAYER_VOTE_THRESHOLD;
 }
@@ -282,4 +282,9 @@ pub fn assert_events(mut expected: Vec<Event>) {
         let next = actual.pop().expect("event expected");
         assert_eq!(next, evt.into(), "Events don't match (actual,expected)");
     }
+}
+
+// Build a dummy proposal for testing
+pub fn make_proposal(r: Vec<u8>) -> Call {
+    Call::System(frame_system::Call::remark(r))
 }

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -235,7 +235,7 @@ impl TestExternalitiesBuilder {
         externalities
     }
 
-    pub fn build_with(
+    pub(crate) fn build_with(
         self,
         src_id: ChainId,
         r_id: ResourceId,

--- a/chainbridge/src/tests.rs
+++ b/chainbridge/src/tests.rs
@@ -339,10 +339,6 @@ fn add_remove_relayer() {
         })
 }
 
-fn make_proposal(r: Vec<u8>) -> mock::Call {
-    mock::Call::System(frame_system::Call::remark(r))
-}
-
 #[test]
 fn create_sucessful_proposal() {
     let src_id: ChainId = 1;

--- a/example-erc721/src/lib.rs
+++ b/example-erc721/src/lib.rs
@@ -151,28 +151,6 @@ pub mod pallet {
     pub(super) type TokenCount<T: Config> = StorageValue<_, U256, ValueQuery, OnTokenCountEmpty<T>>;
 
     // ------------------------------------------------------------------------
-    // Pallet genesis configuration
-    // ------------------------------------------------------------------------
-
-    // The genesis configuration type.
-    #[pallet::genesis_config]
-    pub struct GenesisConfig {}
-
-    // The default value for the genesis config type.
-    #[cfg(feature = "std")]
-    impl Default for GenesisConfig {
-        fn default() -> Self {
-            Self {}
-        }
-    }
-
-    // The build of genesis for the pallet.
-    #[pallet::genesis_build]
-    impl<T: Config> GenesisBuild<T> for GenesisConfig {
-        fn build(&self) {}
-    }
-
-    // ------------------------------------------------------------------------
     // Pallet lifecycle hooks
     // ------------------------------------------------------------------------
 

--- a/example-pallet/src/mock.rs
+++ b/example-pallet/src/mock.rs
@@ -94,7 +94,7 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Config<T>, Storage, Event<T>},
-        ChainBridge: chainbridge::{Pallet, Call, Storage, Config, Event<T>},
+        ChainBridge: chainbridge::{Pallet, Call, Storage, Event<T>},
         Erc721: pallet_example_erc721::{Pallet, Call, Storage, Event<T>},
         Example: pallet_example::{Pallet, Call, Event<T>}
     }


### PR DESCRIPTION
This PR is a minor modification to remove genesis config from chainbridge and examples.