### PR TITLE
Upgrade to polkadot v0.9.31

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install latest nightly Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-03-18
+          toolchain: nightly-2022-05-09
           target: ${{ matrix.target }}
           override: true
       - name: Build chainbridge Rust crate
@@ -41,7 +41,7 @@ jobs:
       - name: Install latest nightly Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-03-18
+          toolchain: nightly-2022-05-09
           target: ${{ matrix.target }}
           override: true
       - name: Build Rust create
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-03-18
+          toolchain: nightly-2022-05-09
           target: ${{ matrix.target }}
           components: rustfmt
           override: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,19 +81,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-bytes"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "arrayvec"
@@ -158,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,16 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
 dependencies = [
  "digest 0.10.5",
-]
-
-[[package]]
-name = "blake2-rfc"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-dependencies = [
- "arrayvec 0.4.12",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -329,12 +322,6 @@ name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation-sys"
@@ -625,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -638,7 +625,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -673,7 +660,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -698,13 +685,14 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
+ "sp-weights",
  "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -718,7 +706,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -730,7 +718,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -740,7 +728,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "frame-support",
  "log",
@@ -752,6 +740,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version",
+ "sp-weights",
 ]
 
 [[package]]
@@ -1015,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -1223,9 +1212,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memory-db"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6566c70c1016f525ced45d7b7f97730a2bafb037c788211d0c186ef5b2189f0a"
+checksum = "34ac11bb793c28fa095b7554466f53b3a60a2cd002afdac01bcf135cbd73a269"
 dependencies = [
  "hash-db",
  "hashbrown",
@@ -1234,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "memory_units"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "merlin"
@@ -1269,7 +1258,7 @@ dependencies = [
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "rand 0.8.5",
  "rand_distr",
@@ -1289,12 +1278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,9 +1285,9 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1342,23 +1325,12 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1413,7 +1385,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1492,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
+checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
 dependencies = [
  "cfg-if",
  "hashbrown",
@@ -1518,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.42.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking_lot"
@@ -1582,6 +1554,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,9 +1572,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -1886,6 +1869,7 @@ checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der",
  "generic-array 0.14.6",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -2043,7 +2027,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "hash-db",
  "log",
@@ -2061,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -2073,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2086,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -2101,18 +2085,18 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
+ "array-bytes",
  "base58",
  "bitflags",
- "blake2-rfc",
+ "blake2",
  "byteorder",
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "hex",
  "impl-serde",
  "lazy_static",
  "libsecp256k1",
@@ -2147,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "blake2",
  "byteorder",
@@ -2161,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2172,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2182,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -2193,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -2207,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "bytes",
  "futures",
@@ -2233,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "async-trait",
  "futures",
@@ -2249,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2259,7 +2243,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -2276,12 +2260,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-std",
+ "sp-weights",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -2299,7 +2284,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -2311,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2322,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "hash-db",
  "log",
@@ -2344,12 +2329,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2362,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -2374,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "ahash",
  "hash-db",
@@ -2397,7 +2382,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2414,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -2425,13 +2410,39 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "sp-std",
  "wasmi",
+]
+
+[[package]]
+name = "sp-weights"
+version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.31#7a4e5163091384c4c10b6d76f5cb80dac0834f38"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-debug-derive",
+ "sp-std",
+]
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2844,26 +2855,35 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasmi"
-version = "0.9.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
+checksum = "06c326c93fbf86419608361a2c925a31754cf109da1b8b55737070b4d6669422"
 dependencies = [
- "downcast-rs",
- "libc",
- "memory_units",
- "num-rational 0.2.4",
- "num-traits",
  "parity-wasm",
  "wasmi-validation",
+ "wasmi_core",
 ]
 
 [[package]]
 name = "wasmi-validation"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
+checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
 dependencies = [
  "parity-wasm",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d20cb3c59b788653d99541c646c561c9dd26506f25c0cebfe810659c54c6d7"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "memory_units",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]

--- a/chainbridge/Cargo.toml
+++ b/chainbridge/Cargo.toml
@@ -10,19 +10,19 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.102", optional = true }
 
 # primitives
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 
 # frame dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
 # Benchmarking primitives
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false, optional = true, branch = "polkadot-v0.9.31" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "3.0.0", package = "substrate-wasm-builder-runner"}

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -125,9 +125,9 @@ use codec::EncodeLike;
 
 use frame_support::{
     dispatch::DispatchResult,
+    dispatch::GetDispatchInfo,
     ensure,
     traits::{EnsureOrigin, Get},
-    weights::GetDispatchInfo,
     PalletId, Parameter,
 };
 
@@ -162,7 +162,6 @@ pub mod pallet {
     use super::*;
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
-    // use mock::RuntimeEvent;
     use sp_std::convert::TryInto;
 
     // Bridge pallet type declaration.

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -162,6 +162,7 @@ pub mod pallet {
     use super::*;
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
+    // use mock::RuntimeEvent;
     use sp_std::convert::TryInto;
 
     // Bridge pallet type declaration.
@@ -185,14 +186,14 @@ pub mod pallet {
     #[pallet::config]
     pub trait Config: frame_system::Config {
         /// Associated type for Event enum
-        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// Origin used for pallet administration
-        type AdminOrigin: EnsureOrigin<Self::Origin>;
+        type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
         /// Proposed dispatchable call
         type Proposal: Parameter
-            + Dispatchable<Origin = Self::Origin>
+            + Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
             + EncodeLike
             + GetDispatchInfo;
 
@@ -527,7 +528,7 @@ impl<T: Config> Pallet<T> {
         T::PalletId::get().into_account_truncating()
     }
 
-    pub fn ensure_admin(o: T::Origin) -> DispatchResult {
+    pub fn ensure_admin(o: T::RuntimeOrigin) -> DispatchResult {
         T::AdminOrigin::try_origin(o)
             .map(|_| ())
             .or_else(ensure_root)?;
@@ -790,14 +791,14 @@ impl<T: Config> Pallet<T> {
 /// Simple ensure origin for the bridge account
 pub struct EnsureBridge<T>(sp_std::marker::PhantomData<T>);
 
-impl<T: pallet::Config> EnsureOrigin<T::Origin> for EnsureBridge<T> {
+impl<T: pallet::Config> EnsureOrigin<T::RuntimeOrigin> for EnsureBridge<T> {
     type Success = T::AccountId;
 
-    fn try_origin(o: T::Origin) -> Result<Self::Success, T::Origin> {
+    fn try_origin(o: T::RuntimeOrigin) -> Result<Self::Success, T::RuntimeOrigin> {
         let bridge_id = T::PalletId::get().into_account_truncating();
         o.into().and_then(|o| match o {
             SystemOrigin::Signed(who) if who == bridge_id => Ok(bridge_id),
-            r => Err(T::Origin::from(r)),
+            r => Err(T::RuntimeOrigin::from(r)),
         })
     }
 
@@ -805,10 +806,10 @@ impl<T: pallet::Config> EnsureOrigin<T::Origin> for EnsureBridge<T> {
     ///
     /// ** Should be used for benchmarking only!!! **
     #[cfg(feature = "runtime-benchmarks")]
-    fn successful_origin() -> T::Origin {
+    fn successful_origin() -> T::RuntimeOrigin {
         let bridge_id = T::PalletId::get().into_account_truncating();
 
-        T::Origin::from(SystemOrigin::Signed(bridge_id))
+        T::RuntimeOrigin::from(SystemOrigin::Signed(bridge_id))
     }
 }
 

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -147,8 +147,8 @@ parameter_types! {
 // Implement FRAME system pallet configuration trait for the mock runtime
 impl frame_system::Config for MockRuntime {
     type BaseCallFilter = Everything;
-    type Origin = Origin;
-    type Call = Call;
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
     type Index = u64;
     type BlockNumber = u64;
     type Hash = H256;
@@ -156,7 +156,7 @@ impl frame_system::Config for MockRuntime {
     type AccountId = u64;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type BlockHashCount = BlockHashCount;
     type DbWeight = ();
     type Version = ();
@@ -181,7 +181,7 @@ parameter_types! {
 impl pallet_balances::Config for MockRuntime {
     type Balance = Balance;
     type DustRemoval = ();
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
     type MaxLocks = ();
@@ -200,8 +200,8 @@ parameter_types! {
 
 // Implement chainbridge pallet configuration trait for the mock runtime
 impl ChainBridgePalletConfig for MockRuntime {
-    type Event = Event;
-    type Proposal = Call;
+    type RuntimeEvent = RuntimeEvent;
+    type Proposal = RuntimeCall;
     type ChainId = MockChainId;
     type PalletId = ChainBridgePalletId;
     type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
@@ -260,18 +260,22 @@ impl TestExternalitiesBuilder {
         externalities.execute_with(|| {
             // Set and check threshold
             assert_ok!(ChainBridge::set_threshold(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 TEST_RELAYER_VOTE_THRESHOLD
             ));
             assert_eq!(ChainBridge::get_threshold(), TEST_RELAYER_VOTE_THRESHOLD);
             // Add relayers
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_A));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_B));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_C));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_A));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_B));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_C));
             // Whitelist chain
-            assert_ok!(ChainBridge::whitelist_chain(Origin::root(), src_id));
+            assert_ok!(ChainBridge::whitelist_chain(RuntimeOrigin::root(), src_id));
             // Set and check resource ID mapped to some junk data
-            assert_ok!(ChainBridge::set_resource(Origin::root(), r_id, resource));
+            assert_ok!(ChainBridge::set_resource(
+                RuntimeOrigin::root(),
+                r_id,
+                resource
+            ));
             assert_eq!(ChainBridge::resource_exists(r_id), true);
         });
 
@@ -285,12 +289,12 @@ impl TestExternalitiesBuilder {
 
 pub mod helpers {
 
-    use super::{Event, MockRuntime};
+    use super::{MockRuntime, RuntimeEvent};
 
     // Checks events against the latest. A contiguous set of events must be provided. They must
     // include the most recent event, but do not have to include every past event.
-    pub fn assert_events(mut expected: Vec<Event>) {
-        let mut actual: Vec<Event> = frame_system::Pallet::<MockRuntime>::events()
+    pub fn assert_events(mut expected: Vec<RuntimeEvent>) {
+        let mut actual: Vec<RuntimeEvent> = frame_system::Pallet::<MockRuntime>::events()
             .iter()
             .map(|e| e.event.clone())
             .collect();

--- a/chainbridge/src/tests.rs
+++ b/chainbridge/src/tests.rs
@@ -22,9 +22,9 @@ use crate::{
     self as pallet_chainbridge,
     constants::DEFAULT_RELAYER_VOTE_THRESHOLD,
     mock::{
-        helpers::*, Balances, Call, ChainBridge, Event, MockRuntime, Origin, ProposalLifetime,
-        System, SystemCall, TestExternalitiesBuilder, ENDOWED_BALANCE, RELAYER_A, RELAYER_B,
-        RELAYER_C, TEST_RELAYER_VOTE_THRESHOLD,
+        helpers::*, Balances, ChainBridge, MockRuntime, ProposalLifetime, RuntimeCall,
+        RuntimeEvent, RuntimeOrigin, System, SystemCall, TestExternalitiesBuilder, ENDOWED_BALANCE,
+        RELAYER_A, RELAYER_B, RELAYER_C, TEST_RELAYER_VOTE_THRESHOLD,
     },
     types::{ProposalStatus, ProposalVotes},
 };
@@ -109,20 +109,20 @@ fn setup_resources() {
             let method2 = "Pallet.do_somethingElse".as_bytes().to_vec();
 
             assert_ok!(ChainBridge::set_resource(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 id,
                 method.clone()
             ));
             assert_eq!(ChainBridge::get_resources(id), Some(method));
 
             assert_ok!(ChainBridge::set_resource(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 id,
                 method2.clone()
             ));
             assert_eq!(ChainBridge::get_resources(id), Some(method2));
 
-            assert_ok!(ChainBridge::remove_resource(Origin::root(), id));
+            assert_ok!(ChainBridge::remove_resource(RuntimeOrigin::root(), id));
             assert_eq!(ChainBridge::get_resources(id), None);
         })
 }
@@ -134,16 +134,18 @@ fn whitelist_chain() {
         .execute_with(|| {
             assert!(!ChainBridge::chain_whitelisted(0));
 
-            assert_ok!(ChainBridge::whitelist_chain(Origin::root(), 0));
+            assert_ok!(ChainBridge::whitelist_chain(RuntimeOrigin::root(), 0));
             assert_noop!(
                 ChainBridge::whitelist_chain(
-                    Origin::root(),
+                    RuntimeOrigin::root(),
                     <MockRuntime as pallet_chainbridge::Config>::ChainId::get()
                 ),
                 Error::<MockRuntime>::InvalidChainId
             );
 
-            assert_events(vec![Event::ChainBridge(crate::Event::ChainWhitelisted(0))]);
+            assert_events(vec![RuntimeEvent::ChainBridge(
+                crate::Event::ChainWhitelisted(0),
+            )]);
         })
 }
 
@@ -155,19 +157,19 @@ fn set_get_threshold() {
             assert_eq!(ChainBridge::get_threshold(), DEFAULT_RELAYER_VOTE_THRESHOLD);
 
             assert_ok!(ChainBridge::set_threshold(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 TEST_RELAYER_VOTE_THRESHOLD
             ));
             assert_eq!(ChainBridge::get_threshold(), TEST_RELAYER_VOTE_THRESHOLD);
 
-            assert_ok!(ChainBridge::set_threshold(Origin::root(), 5));
+            assert_ok!(ChainBridge::set_threshold(RuntimeOrigin::root(), 5));
             assert_eq!(ChainBridge::get_threshold(), 5);
 
             assert_events(vec![
-                Event::ChainBridge(pallet::Event::<MockRuntime>::RelayerThresholdChanged(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::RelayerThresholdChanged(
                     TEST_RELAYER_VOTE_THRESHOLD,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::RelayerThresholdChanged(5)),
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::RelayerThresholdChanged(5)),
             ]);
         })
 }
@@ -185,12 +187,12 @@ fn asset_transfer_success() {
             let token_id = vec![1, 2, 3, 4];
 
             assert_ok!(ChainBridge::set_threshold(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 TEST_RELAYER_VOTE_THRESHOLD
             ));
 
             assert_ok!(ChainBridge::whitelist_chain(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 dest_id.clone()
             ));
             assert_ok!(ChainBridge::transfer_fungible(
@@ -201,10 +203,10 @@ fn asset_transfer_success() {
             ));
 
             assert_events(vec![
-                Event::ChainBridge(pallet::Event::<MockRuntime>::ChainWhitelisted(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::ChainWhitelisted(
                     dest_id.clone(),
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::FungibleTransfer(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::FungibleTransfer(
                     dest_id.clone(),
                     1,
                     resource_id.clone(),
@@ -257,7 +259,7 @@ fn asset_transfer_invalid_chain() {
             let resource_id = [4; 32];
 
             assert_ok!(ChainBridge::whitelist_chain(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 chain_id.clone()
             ));
             assert_events(vec![Event::ChainBridge(
@@ -298,27 +300,30 @@ fn add_remove_relayer() {
         .build()
         .execute_with(|| {
             assert_ok!(ChainBridge::set_threshold(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 TEST_RELAYER_VOTE_THRESHOLD,
             ));
             assert_eq!(ChainBridge::get_relayer_count(), 0);
 
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_A));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_B));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_C));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_A));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_B));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_C));
             assert_eq!(ChainBridge::get_relayer_count(), 3);
 
             // Already exists
             assert_noop!(
-                ChainBridge::add_relayer(Origin::root(), RELAYER_A),
+                ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_A),
                 Error::<MockRuntime>::RelayerAlreadyExists
             );
 
             // Confirm removal
-            assert_ok!(ChainBridge::remove_relayer(Origin::root(), RELAYER_B));
+            assert_ok!(ChainBridge::remove_relayer(
+                RuntimeOrigin::root(),
+                RELAYER_B
+            ));
             assert_eq!(ChainBridge::get_relayer_count(), 2);
             assert_noop!(
-                ChainBridge::remove_relayer(Origin::root(), RELAYER_B),
+                ChainBridge::remove_relayer(RuntimeOrigin::root(), RELAYER_B),
                 Error::<MockRuntime>::RelayerInvalid
             );
             assert_eq!(ChainBridge::get_relayer_count(), 2);
@@ -346,7 +351,7 @@ fn create_successful_remark_proposal() {
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 prop_id,
                 src_id,
                 r_id,
@@ -365,7 +370,7 @@ fn create_successful_remark_proposal() {
 
             // Second relayer votes against
             assert_ok!(ChainBridge::reject_proposal(
-                Origin::signed(RELAYER_B),
+                RuntimeOrigin::signed(RELAYER_B),
                 prop_id,
                 src_id,
                 r_id,
@@ -384,7 +389,7 @@ fn create_successful_remark_proposal() {
 
             // Third relayer votes in favour
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_C),
+                RuntimeOrigin::signed(RELAYER_C),
                 prop_id,
                 src_id,
                 r_id,
@@ -436,7 +441,7 @@ fn create_unsuccessful_transfer_proposal() {
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 prop_id,
                 src_id,
                 r_id,
@@ -453,7 +458,7 @@ fn create_unsuccessful_transfer_proposal() {
 
             // Second relayer votes against
             assert_ok!(ChainBridge::reject_proposal(
-                Origin::signed(RELAYER_B),
+                RuntimeOrigin::signed(RELAYER_B),
                 prop_id,
                 src_id,
                 r_id,
@@ -470,7 +475,7 @@ fn create_unsuccessful_transfer_proposal() {
 
             // Third relayer votes against
             assert_ok!(ChainBridge::reject_proposal(
-                Origin::signed(RELAYER_C),
+                RuntimeOrigin::signed(RELAYER_C),
                 prop_id,
                 src_id,
                 r_id,
@@ -523,7 +528,7 @@ fn execute_after_threshold_change() {
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 prop_id,
                 src_id,
                 r_id,
@@ -539,11 +544,11 @@ fn execute_after_threshold_change() {
             assert_eq!(prop, expected);
 
             // Change threshold
-            assert_ok!(ChainBridge::set_threshold(Origin::root(), 1));
+            assert_ok!(ChainBridge::set_threshold(RuntimeOrigin::root(), 1));
 
             // Attempt to execute
             assert_ok!(ChainBridge::eval_vote_state(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 prop_id,
                 src_id,
                 Box::new(proposal.clone())
@@ -594,7 +599,7 @@ fn proposal_expires() {
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 prop_id,
                 src_id,
                 r_id,
@@ -615,7 +620,7 @@ fn proposal_expires() {
             // Attempt to submit a vote should fail
             assert_noop!(
                 ChainBridge::reject_proposal(
-                    Origin::signed(RELAYER_B),
+                    RuntimeOrigin::signed(RELAYER_B),
                     prop_id,
                     src_id,
                     r_id,
@@ -637,7 +642,7 @@ fn proposal_expires() {
             // eval_vote_state should have no effect
             assert_noop!(
                 ChainBridge::eval_vote_state(
-                    Origin::signed(RELAYER_C),
+                    RuntimeOrigin::signed(RELAYER_C),
                     prop_id,
                     src_id,
                     Box::new(proposal.clone())
@@ -653,8 +658,10 @@ fn proposal_expires() {
             };
             assert_eq!(prop, expected);
 
-            assert_events(vec![mock::Event::ChainBridge(
-                pallet::Event::<MockRuntime>::VoteFor(src_id, prop_id, RELAYER_A),
-            )]);
+            assert_events(vec![mock::RuntimeEvent::ChainBridge(pallet::Event::<
+                MockRuntime,
+            >::VoteFor(
+                src_id, prop_id, RELAYER_A,
+            ))]);
         })
 }

--- a/chainbridge/src/tests.rs
+++ b/chainbridge/src/tests.rs
@@ -222,7 +222,7 @@ fn asset_transfer_success() {
                 to.clone(),
                 metadata.clone()
             ));
-            assert_events(vec![Event::ChainBridge(
+            assert_events(vec![RuntimeEvent::ChainBridge(
                 pallet::Event::<MockRuntime>::NonFungibleTransfer(
                     dest_id.clone(),
                     2,
@@ -238,7 +238,7 @@ fn asset_transfer_success() {
                 resource_id.clone(),
                 metadata.clone()
             ));
-            assert_events(vec![Event::ChainBridge(
+            assert_events(vec![RuntimeEvent::ChainBridge(
                 pallet::Event::<MockRuntime>::GenericTransfer(
                     dest_id.clone(),
                     3,
@@ -262,7 +262,7 @@ fn asset_transfer_invalid_chain() {
                 RuntimeOrigin::root(),
                 chain_id.clone()
             ));
-            assert_events(vec![Event::ChainBridge(
+            assert_events(vec![RuntimeEvent::ChainBridge(
                 pallet::Event::<MockRuntime>::ChainWhitelisted(chain_id.clone()),
             )]);
 
@@ -328,10 +328,10 @@ fn add_remove_relayer() {
             );
             assert_eq!(ChainBridge::get_relayer_count(), 2);
             assert_events(vec![
-                Event::ChainBridge(pallet::Event::<MockRuntime>::RelayerAdded(RELAYER_A)),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::RelayerAdded(RELAYER_B)),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::RelayerAdded(RELAYER_C)),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::RelayerRemoved(RELAYER_B)),
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::RelayerAdded(RELAYER_A)),
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::RelayerAdded(RELAYER_B)),
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::RelayerAdded(RELAYER_C)),
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::RelayerRemoved(RELAYER_B)),
             ]);
         })
 }
@@ -347,7 +347,7 @@ fn create_successful_remark_proposal() {
             let prop_id = 1;
 
             // Create a dummy system remark proposal
-            let proposal = Call::System(SystemCall::remark { remark: vec![10] });
+            let proposal = RuntimeCall::System(SystemCall::remark { remark: vec![10] });
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
@@ -407,19 +407,19 @@ fn create_successful_remark_proposal() {
             assert_eq!(prop, expected);
 
             assert_events(vec![
-                Event::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
                     src_id, prop_id, RELAYER_A,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::VoteAgainst(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::VoteAgainst(
                     src_id, prop_id, RELAYER_B,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
                     src_id, prop_id, RELAYER_C,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::ProposalApproved(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::ProposalApproved(
                     src_id, prop_id,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::ProposalSucceeded(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::ProposalSucceeded(
                     src_id, prop_id,
                 )),
             ]);
@@ -437,7 +437,7 @@ fn create_unsuccessful_transfer_proposal() {
             let prop_id = 1;
 
             // Create a dummy system remark proposal
-            let proposal = Call::System(SystemCall::remark { remark: vec![11] });
+            let proposal = RuntimeCall::System(SystemCall::remark { remark: vec![11] });
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
@@ -497,16 +497,16 @@ fn create_unsuccessful_transfer_proposal() {
             );
 
             assert_events(vec![
-                Event::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
                     src_id, prop_id, RELAYER_A,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::VoteAgainst(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::VoteAgainst(
                     src_id, prop_id, RELAYER_B,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::VoteAgainst(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::VoteAgainst(
                     src_id, prop_id, RELAYER_C,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::ProposalRejected(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::ProposalRejected(
                     src_id, prop_id,
                 )),
             ]);
@@ -524,7 +524,7 @@ fn execute_after_threshold_change() {
             let prop_id = 1;
 
             // Create a dummy system remark proposal
-            let proposal = Call::System(SystemCall::remark { remark: vec![11] });
+            let proposal = RuntimeCall::System(SystemCall::remark { remark: vec![11] });
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
@@ -570,14 +570,14 @@ fn execute_after_threshold_change() {
             );
 
             assert_events(vec![
-                Event::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::VoteFor(
                     src_id, prop_id, RELAYER_A,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::RelayerThresholdChanged(1)),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::ProposalApproved(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::RelayerThresholdChanged(1)),
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::ProposalApproved(
                     src_id, prop_id,
                 )),
-                Event::ChainBridge(pallet::Event::<MockRuntime>::ProposalSucceeded(
+                RuntimeEvent::ChainBridge(pallet::Event::<MockRuntime>::ProposalSucceeded(
                     src_id, prop_id,
                 )),
             ]);
@@ -595,7 +595,7 @@ fn proposal_expires() {
             let prop_id = 1;
 
             // Create a dummy system remark proposal
-            let proposal = Call::System(SystemCall::remark { remark: vec![10] });
+            let proposal = RuntimeCall::System(SystemCall::remark { remark: vec![10] });
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(

--- a/example-erc721/Cargo.toml
+++ b/example-erc721/Cargo.toml
@@ -10,21 +10,21 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.102", optional = true }
 
 # primitives
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 
 # frame dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
 # local dependencies
 chainbridge = { path = "../chainbridge" , default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "3.0.0", package = "substrate-wasm-builder-runner"}

--- a/example-erc721/src/lib.rs
+++ b/example-erc721/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
     #[pallet::config]
     pub trait Config: frame_system::Config {
         /// Associated type for Event enum
-        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// Some identifier for this token type, possibly the originating ethereum address.
         /// This is not explicitly used for anything, but may reflect the bridge's notion of resource ID.

--- a/example-erc721/src/mock.rs
+++ b/example-erc721/src/mock.rs
@@ -94,8 +94,8 @@ parameter_types! {
 // Implement FRAME system pallet configuration trait for the mock runtime
 impl frame_system::Config for MockRuntime {
     type BaseCallFilter = Everything;
-    type Origin = Origin;
-    type Call = Call;
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
     type Index = u64;
     type BlockNumber = u64;
     type Hash = H256;
@@ -103,7 +103,7 @@ impl frame_system::Config for MockRuntime {
     type AccountId = u64;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type BlockHashCount = BlockHashCount;
     type DbWeight = ();
     type Version = ();
@@ -128,7 +128,7 @@ parameter_types! {
 impl pallet_balances::Config for MockRuntime {
     type Balance = Balance;
     type DustRemoval = ();
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
     type MaxReserves = ();
@@ -144,7 +144,7 @@ parameter_types! {
 
 // Implement FRAME ERC721 pallet configuration trait for the mock runtime
 impl pallet_example_erc721::Config for MockRuntime {
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type Identifier = Erc721Id;
     type WeightInfo = MockWeightInfo;
 }

--- a/example-erc721/src/tests.rs
+++ b/example-erc721/src/tests.rs
@@ -38,7 +38,7 @@ fn mint_burn_tokens() {
             let metadata_b: Vec<u8> = vec![4, 5, 6];
 
             assert_ok!(Erc721::mint(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 USER_A,
                 id_a,
                 metadata_a.clone()
@@ -52,12 +52,12 @@ fn mint_burn_tokens() {
             );
             assert_eq!(Erc721::get_token_count(), 1.into());
             assert_noop!(
-                Erc721::mint(Origin::root(), USER_A, id_a, metadata_a.clone()),
+                Erc721::mint(RuntimeOrigin::root(), USER_A, id_a, metadata_a.clone()),
                 Error::<MockRuntime>::TokenAlreadyExists
             );
 
             assert_ok!(Erc721::mint(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 USER_A,
                 id_b,
                 metadata_b.clone()
@@ -71,16 +71,16 @@ fn mint_burn_tokens() {
             );
             assert_eq!(Erc721::get_token_count(), 2.into());
             assert_noop!(
-                Erc721::mint(Origin::root(), USER_A, id_b, metadata_b.clone()),
+                Erc721::mint(RuntimeOrigin::root(), USER_A, id_b, metadata_b.clone()),
                 Error::<MockRuntime>::TokenAlreadyExists
             );
 
-            assert_ok!(Erc721::burn(Origin::root(), id_a));
+            assert_ok!(Erc721::burn(RuntimeOrigin::root(), id_a));
             assert_eq!(Erc721::get_token_count(), 1.into());
             assert!(!<Tokens<MockRuntime>>::contains_key(&id_a));
             assert!(!<TokenOwner<MockRuntime>>::contains_key(&id_a));
 
-            assert_ok!(Erc721::burn(Origin::root(), id_b));
+            assert_ok!(Erc721::burn(RuntimeOrigin::root(), id_b));
             assert_eq!(Erc721::get_token_count(), 0.into());
             assert!(!<Tokens<MockRuntime>>::contains_key(&id_b));
             assert!(!<TokenOwner<MockRuntime>>::contains_key(&id_b));
@@ -98,28 +98,44 @@ fn transfer_tokens() {
             let metadata_b: Vec<u8> = vec![4, 5, 6];
 
             assert_ok!(Erc721::mint(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 USER_A,
                 id_a,
                 metadata_a.clone()
             ));
             assert_ok!(Erc721::mint(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 USER_A,
                 id_b,
                 metadata_b.clone()
             ));
 
-            assert_ok!(Erc721::transfer(Origin::signed(USER_A), USER_B, id_a));
+            assert_ok!(Erc721::transfer(
+                RuntimeOrigin::signed(USER_A),
+                USER_B,
+                id_a
+            ));
             assert_eq!(Erc721::get_owner_of(id_a).unwrap(), USER_B);
 
-            assert_ok!(Erc721::transfer(Origin::signed(USER_A), USER_C, id_b));
+            assert_ok!(Erc721::transfer(
+                RuntimeOrigin::signed(USER_A),
+                USER_C,
+                id_b
+            ));
             assert_eq!(Erc721::get_owner_of(id_b).unwrap(), USER_C);
 
-            assert_ok!(Erc721::transfer(Origin::signed(USER_B), USER_A, id_a));
+            assert_ok!(Erc721::transfer(
+                RuntimeOrigin::signed(USER_B),
+                USER_A,
+                id_a
+            ));
             assert_eq!(Erc721::get_owner_of(id_a).unwrap(), USER_A);
 
-            assert_ok!(Erc721::transfer(Origin::signed(USER_C), USER_A, id_b));
+            assert_ok!(Erc721::transfer(
+                RuntimeOrigin::signed(USER_C),
+                USER_A,
+                id_b
+            ));
             assert_eq!(Erc721::get_owner_of(id_b).unwrap(), USER_A);
         })
 }

--- a/example-pallet/Cargo.toml
+++ b/example-pallet/Cargo.toml
@@ -10,15 +10,15 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.101", optional = true }
 
 # primitives
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 
 # frame dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
 # local dependencies
@@ -26,7 +26,7 @@ chainbridge = { path = "../chainbridge" , default-features = false}
 pallet-example-erc721 = { path = "../example-erc721", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.31" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "3.0.0", package = "substrate-wasm-builder-runner"}

--- a/example-pallet/src/lib.rs
+++ b/example-pallet/src/lib.rs
@@ -95,11 +95,11 @@ pub mod pallet {
     #[pallet::config]
     pub trait Config: frame_system::Config + chainbridge::Config + erc721::Config {
         /// Associated type for Event enum
-        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// Specifies the origin check provided by the bridge for calls that can only be called by the bridge pallet
         type BridgeOrigin: EnsureOrigin<
-            <Self as frame_system::Config>::Origin,
+            <Self as frame_system::Config>::RuntimeOrigin,
             Success = <Self as frame_system::Config>::AccountId,
         >;
 

--- a/example-pallet/src/mock.rs
+++ b/example-pallet/src/mock.rs
@@ -128,8 +128,8 @@ parameter_types! {
 // Implement FRAME system pallet configuration trait for the mock runtime
 impl frame_system::Config for MockRuntime {
     type BaseCallFilter = Everything;
-    type Origin = Origin;
-    type Call = Call;
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
     type Index = u64;
     type BlockNumber = u64;
     type Hash = H256;
@@ -137,7 +137,7 @@ impl frame_system::Config for MockRuntime {
     type AccountId = u64;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type BlockHashCount = BlockHashCount;
     type DbWeight = ();
     type Version = ();
@@ -162,7 +162,7 @@ parameter_types! {
 impl pallet_balances::Config for MockRuntime {
     type Balance = Balance;
     type DustRemoval = ();
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
     type MaxLocks = ();
@@ -181,8 +181,8 @@ parameter_types! {
 
 // Implement chainbridge pallet configuration trait for the mock runtime
 impl chainbridge::Config for MockRuntime {
-    type Event = Event;
-    type Proposal = Call;
+    type RuntimeEvent = RuntimeEvent;
+    type Proposal = RuntimeCall;
     type ChainId = MockChainId;
     type PalletId = ChainBridgePalletId;
     type AdminOrigin = EnsureRoot<Self::AccountId>;
@@ -200,14 +200,14 @@ parameter_types! {
 
 // Implement ERC721 pallet configuration trait for the mock runtime
 impl pallet_example_erc721::Config for MockRuntime {
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type Identifier = Erc721Id;
     type WeightInfo = ();
 }
 
 // Implement example pallet configuration trait for the mock runtime
 impl PalletExampleConfig for MockRuntime {
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type BridgeOrigin = chainbridge::EnsureBridge<MockRuntime>;
     type Currency = Balances;
     type HashId = HashId;
@@ -261,26 +261,26 @@ impl TestExternalitiesBuilder {
 
 pub(crate) mod helpers {
 
-    use super::{Call, Event, HashId, MockRuntime, H256};
+    use super::{HashId, MockRuntime, RuntimeCall, RuntimeEvent, H256};
 
-    fn last_event() -> Event {
+    fn last_event() -> RuntimeEvent {
         frame_system::Pallet::<MockRuntime>::events()
             .pop()
             .map(|e| e.event)
             .expect("Event expected")
     }
 
-    pub fn expect_event<E: Into<Event>>(e: E) {
+    pub fn expect_event<E: Into<RuntimeEvent>>(e: E) {
         assert_eq!(last_event(), e.into());
     }
 
     // Asserts that the event was emitted at some point.
-    pub fn event_exists<E: Into<Event>>(e: E) {
-        let actual: Vec<Event> = frame_system::Pallet::<MockRuntime>::events()
+    pub fn event_exists<E: Into<RuntimeEvent>>(e: E) {
+        let actual: Vec<RuntimeEvent> = frame_system::Pallet::<MockRuntime>::events()
             .iter()
             .map(|e| e.event.clone())
             .collect();
-        let e: Event = e.into();
+        let e: RuntimeEvent = e.into();
         let mut exists = false;
         for evt in actual {
             if evt == e {
@@ -293,8 +293,8 @@ pub(crate) mod helpers {
 
     // Checks events against the latest. A contiguous set of events must be provided. They must
     // include the most recent event, but do not have to include every past event.
-    pub fn assert_events(mut expected: Vec<Event>) {
-        let mut actual: Vec<Event> = frame_system::Pallet::<MockRuntime>::events()
+    pub fn assert_events(mut expected: Vec<RuntimeEvent>) {
+        let mut actual: Vec<RuntimeEvent> = frame_system::Pallet::<MockRuntime>::events()
             .iter()
             .map(|e| e.event.clone())
             .collect();
@@ -307,17 +307,17 @@ pub(crate) mod helpers {
         }
     }
 
-    pub(crate) fn make_remark_proposal(hash: H256) -> Call {
+    pub(crate) fn make_remark_proposal(hash: H256) -> RuntimeCall {
         let resource_id = HashId::get();
-        Call::Example(crate::Call::remark {
+        RuntimeCall::Example(crate::Call::remark {
             hash,
             r_id: resource_id,
         })
     }
 
-    pub(crate) fn make_transfer_proposal(to: u64, amount: u64) -> Call {
+    pub(crate) fn make_transfer_proposal(to: u64, amount: u64) -> RuntimeCall {
         let resource_id = HashId::get();
-        Call::Example(crate::Call::transfer {
+        RuntimeCall::Example(crate::Call::transfer {
             to,
             amount: amount.into(),
             r_id: resource_id,

--- a/example-pallet/src/tests.rs
+++ b/example-pallet/src/tests.rs
@@ -22,7 +22,7 @@ use crate::{
     self as pallet_example,
     mock::{
         helpers::*, Balances, ChainBridge, Erc721, Erc721Id, Example, HashId, MockRuntime,
-        NativeTokenId, Origin, ProposalLifetime, TestExternalitiesBuilder, ENDOWED_BALANCE,
+        NativeTokenId, ProposalLifetime, RuntimeOrigin, TestExternalitiesBuilder, ENDOWED_BALANCE,
         RELAYER_A, RELAYER_B, RELAYER_C, TEST_RELAYER_VOTE_THRESHOLD,
     },
 };
@@ -49,16 +49,16 @@ fn transfer_hash() {
             let hash: H256 = "ABC".using_encoded(blake2_256).into();
 
             assert_ok!(ChainBridge::set_threshold(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 TEST_RELAYER_VOTE_THRESHOLD,
             ));
 
             assert_ok!(ChainBridge::whitelist_chain(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 dest_chain.clone()
             ));
             assert_ok!(Example::transfer_hash(
-                Origin::signed(1),
+                RuntimeOrigin::signed(1),
                 hash.clone(),
                 dest_chain,
             ));
@@ -83,11 +83,11 @@ fn transfer_native() {
             let recipient = vec![99];
 
             assert_ok!(ChainBridge::whitelist_chain(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 dest_chain.clone()
             ));
             assert_ok!(Example::transfer_native(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 amount.clone(),
                 recipient.clone(),
                 dest_chain,
@@ -118,7 +118,7 @@ fn transfer_erc721() {
 
             // Create a token
             assert_ok!(Erc721::mint(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 RELAYER_A,
                 token_id,
                 metadata.clone()
@@ -133,12 +133,12 @@ fn transfer_erc721() {
 
             // Whitelist destination and transfer
             assert_ok!(ChainBridge::whitelist_chain(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 dest_chain.clone()
             ));
 
             assert_ok!(Example::transfer_erc721(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 recipient.clone(),
                 token_id,
                 dest_chain,
@@ -159,7 +159,7 @@ fn transfer_erc721() {
             // Transfer should fail as token doesn't exist
             assert_noop!(
                 Example::transfer_erc721(
-                    Origin::signed(RELAYER_A),
+                    RuntimeOrigin::signed(RELAYER_A),
                     recipient.clone(),
                     token_id,
                     dest_chain,
@@ -182,23 +182,27 @@ fn execute_remark() {
             let resource = b"Example.remark".to_vec();
 
             assert_ok!(ChainBridge::set_threshold(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 TEST_RELAYER_VOTE_THRESHOLD
             ));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_A));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_B));
-            assert_ok!(ChainBridge::whitelist_chain(Origin::root(), src_id));
-            assert_ok!(ChainBridge::set_resource(Origin::root(), r_id, resource));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_A));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_B));
+            assert_ok!(ChainBridge::whitelist_chain(RuntimeOrigin::root(), src_id));
+            assert_ok!(ChainBridge::set_resource(
+                RuntimeOrigin::root(),
+                r_id,
+                resource
+            ));
 
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 prop_id,
                 src_id,
                 r_id,
                 Box::new(proposal.clone())
             ));
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_B),
+                RuntimeOrigin::signed(RELAYER_B),
                 prop_id,
                 src_id,
                 r_id,
@@ -217,18 +221,18 @@ fn execute_remark_bad_origin() {
             let hash: H256 = "ABC".using_encoded(blake2_256).into();
             let resource_id = HashId::get();
             assert_ok!(Example::remark(
-                Origin::signed(ChainBridge::account_id()),
+                RuntimeOrigin::signed(ChainBridge::account_id()),
                 hash,
                 resource_id
             ));
             // Don't allow any signed origin except from bridge addr
             assert_noop!(
-                Example::remark(Origin::signed(RELAYER_A), hash, resource_id),
+                Example::remark(RuntimeOrigin::signed(RELAYER_A), hash, resource_id),
                 DispatchError::BadOrigin
             );
             // Don't allow root calls
             assert_noop!(
-                Example::remark(Origin::root(), hash, resource_id),
+                Example::remark(RuntimeOrigin::root(), hash, resource_id),
                 DispatchError::BadOrigin
             );
         })
@@ -245,7 +249,7 @@ fn transfer() {
             assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
             // Transfer and check result
             assert_ok!(Example::transfer(
-                Origin::signed(ChainBridge::account_id()),
+                RuntimeOrigin::signed(ChainBridge::account_id()),
                 RELAYER_A,
                 10,
                 resource_id,
@@ -253,7 +257,7 @@ fn transfer() {
             assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE - 10);
             assert_eq!(Balances::free_balance(RELAYER_A), ENDOWED_BALANCE + 10);
 
-            assert_events(vec![mock::Event::Balances(
+            assert_events(vec![mock::RuntimeEvent::Balances(
                 pallet_balances::Event::Transfer {
                     from: ChainBridge::account_id(),
                     to: RELAYER_A,
@@ -277,7 +281,7 @@ fn mint_erc721() {
             assert_eq!(Erc721::get_tokens(token_id), None);
             // Mint
             assert_ok!(Example::mint_erc721(
-                Origin::signed(bridge_id),
+                RuntimeOrigin::signed(bridge_id),
                 recipient,
                 token_id,
                 metadata.clone(),
@@ -294,7 +298,7 @@ fn mint_erc721() {
             // Cannot mint same token
             assert_noop!(
                 Example::mint_erc721(
-                    Origin::signed(bridge_id),
+                    RuntimeOrigin::signed(bridge_id),
                     recipient,
                     token_id,
                     metadata.clone(),
@@ -317,18 +321,22 @@ fn create_sucessful_transfer_proposal() {
             let proposal = make_transfer_proposal(RELAYER_A, 10);
 
             assert_ok!(ChainBridge::set_threshold(
-                Origin::root(),
+                RuntimeOrigin::root(),
                 TEST_RELAYER_VOTE_THRESHOLD
             ));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_A));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_B));
-            assert_ok!(ChainBridge::add_relayer(Origin::root(), RELAYER_C));
-            assert_ok!(ChainBridge::whitelist_chain(Origin::root(), src_id));
-            assert_ok!(ChainBridge::set_resource(Origin::root(), r_id, resource));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_A));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_B));
+            assert_ok!(ChainBridge::add_relayer(RuntimeOrigin::root(), RELAYER_C));
+            assert_ok!(ChainBridge::whitelist_chain(RuntimeOrigin::root(), src_id));
+            assert_ok!(ChainBridge::set_resource(
+                RuntimeOrigin::root(),
+                r_id,
+                resource
+            ));
 
             // Create proposal (& vote)
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_A),
+                RuntimeOrigin::signed(RELAYER_A),
                 prop_id,
                 src_id,
                 r_id,
@@ -345,7 +353,7 @@ fn create_sucessful_transfer_proposal() {
 
             // Second relayer votes against
             assert_ok!(ChainBridge::reject_proposal(
-                Origin::signed(RELAYER_B),
+                RuntimeOrigin::signed(RELAYER_B),
                 prop_id,
                 src_id,
                 r_id,
@@ -362,7 +370,7 @@ fn create_sucessful_transfer_proposal() {
 
             // Third relayer votes in favour
             assert_ok!(ChainBridge::acknowledge_proposal(
-                Origin::signed(RELAYER_C),
+                RuntimeOrigin::signed(RELAYER_C),
                 prop_id,
                 src_id,
                 r_id,
@@ -384,18 +392,26 @@ fn create_sucessful_transfer_proposal() {
             );
 
             assert_events(vec![
-                mock::Event::ChainBridge(chainbridge::Event::VoteFor(src_id, prop_id, RELAYER_A)),
-                mock::Event::ChainBridge(chainbridge::Event::VoteAgainst(
+                mock::RuntimeEvent::ChainBridge(chainbridge::Event::VoteFor(
+                    src_id, prop_id, RELAYER_A,
+                )),
+                mock::RuntimeEvent::ChainBridge(chainbridge::Event::VoteAgainst(
                     src_id, prop_id, RELAYER_B,
                 )),
-                mock::Event::ChainBridge(chainbridge::Event::VoteFor(src_id, prop_id, RELAYER_C)),
-                mock::Event::ChainBridge(chainbridge::Event::ProposalApproved(src_id, prop_id)),
-                mock::Event::Balances(pallet_balances::Event::Transfer {
+                mock::RuntimeEvent::ChainBridge(chainbridge::Event::VoteFor(
+                    src_id, prop_id, RELAYER_C,
+                )),
+                mock::RuntimeEvent::ChainBridge(chainbridge::Event::ProposalApproved(
+                    src_id, prop_id,
+                )),
+                mock::RuntimeEvent::Balances(pallet_balances::Event::Transfer {
                     from: ChainBridge::account_id(),
                     to: RELAYER_A,
                     amount: 10,
                 }),
-                mock::Event::ChainBridge(chainbridge::Event::ProposalSucceeded(src_id, prop_id)),
+                mock::RuntimeEvent::ChainBridge(chainbridge::Event::ProposalSucceeded(
+                    src_id, prop_id,
+                )),
             ]);
         })
 }


### PR DESCRIPTION

## Description
This upgrades substrate version to `v0.9.31`.
Once this is approved/merged, I'll then push these changes to new `polkadot-v0.9.31` branch.

## Related Issue Or Context
It addresses the version changes, as well as breaking changes in new polkadot version:
- https://github.com/paritytech/substrate/commit/5527263978a763bafc78d60955c662c20f465d18
- https://github.com/paritytech/substrate/commit/a47f200eebeb88a5bde6f1ed2be9728b82536dde



## How Has This Been Tested? Testing details.
Project tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (Note: this addresses breaking changes in dependencies, but does not introduce new breaking changes)
- [ ] Documentation
